### PR TITLE
Dodanie możliwości triggerowania webhooków getem oraz callbacku zwrac…

### DIFF
--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/WebhookActionDispatcher.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/WebhookActionDispatcher.java
@@ -1,6 +1,7 @@
 package pl.consdata.ico.sqcompanion.hook;
 
 import org.springframework.stereotype.Service;
+import pl.consdata.ico.sqcompanion.hook.action.ActionResponse;
 import pl.consdata.ico.sqcompanion.hook.action.NoImprovementWebhookAction;
 import pl.consdata.ico.sqcompanion.hook.action.NoImprovementWebhookActionData;
 
@@ -12,11 +13,17 @@ public class WebhookActionDispatcher {
     public WebhookActionDispatcher(NoImprovementWebhookAction noImprovementWebhookAction) {
         this.noImprovementWebhookAction = noImprovementWebhookAction;
     }
-
+/*
     public void dispatch(Webhook webhook) {
         if (webhook.getAction().getType().equals(NoImprovementWebhookAction.TYPE)) {
             webhook.getCallbacks().forEach(callback -> callback.call(noImprovementWebhookAction.call(webhook.getGroupUuid(), (NoImprovementWebhookActionData) webhook.getAction())));
         }
-    }
+    }*/
 
+    public ActionResponse dispatch(Webhook webhook) {
+        if (webhook.getAction().getType().equals(NoImprovementWebhookAction.TYPE)) {
+            return noImprovementWebhookAction.call(webhook.getGroupUuid(), (NoImprovementWebhookActionData) webhook.getAction());
+        }
+        return null;
+    }
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/WebhookActionDispatcher.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/WebhookActionDispatcher.java
@@ -13,12 +13,6 @@ public class WebhookActionDispatcher {
     public WebhookActionDispatcher(NoImprovementWebhookAction noImprovementWebhookAction) {
         this.noImprovementWebhookAction = noImprovementWebhookAction;
     }
-/*
-    public void dispatch(Webhook webhook) {
-        if (webhook.getAction().getType().equals(NoImprovementWebhookAction.TYPE)) {
-            webhook.getCallbacks().forEach(callback -> callback.call(noImprovementWebhookAction.call(webhook.getGroupUuid(), (NoImprovementWebhookActionData) webhook.getAction())));
-        }
-    }*/
 
     public ActionResponse dispatch(Webhook webhook) {
         if (webhook.getAction().getType().equals(NoImprovementWebhookAction.TYPE)) {

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/WebhookRestController.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/WebhookRestController.java
@@ -1,0 +1,51 @@
+package pl.consdata.ico.sqcompanion.hook;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import pl.consdata.ico.sqcompanion.hook.action.ActionResponse;
+import pl.consdata.ico.sqcompanion.hook.callback.CallbackResponse;
+import pl.consdata.ico.sqcompanion.hook.callback.WebhookCallback;
+import pl.consdata.ico.sqcompanion.hook.trigger.RestWebhookTrigger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/webhooks")
+public class WebhookRestController {
+
+    private List<Webhook> restWebhooks = new ArrayList<>();
+    private WebhookActionDispatcher dispatcher;
+
+    private WebhookService service;
+
+    public WebhookRestController(WebhookService service, WebhookActionDispatcher dispatcher) {
+        this.service = service;
+        restWebhooks = service.getAllWebhooksWithTrigger(RestWebhookTrigger.class);
+        this.dispatcher = dispatcher;
+    }
+
+    @RequestMapping(value = "/{endpoint}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public CallbackResponse get(@PathVariable String endpoint) {
+        Webhook endpointWebhook = restWebhooks.stream().filter(webhook -> ((RestWebhookTrigger) webhook.getTrigger()).getMethod().equals("GET")
+                && ((RestWebhookTrigger) webhook.getTrigger()).getEndpoint().equals(endpoint)).findFirst().orElse(null);
+        if (endpointWebhook != null) {
+            ActionResponse response = dispatcher.dispatch(endpointWebhook);
+
+            // return last callback response as response for trigger
+            // its author responsibility to ensure that desired callback would be last in config
+            CallbackResponse lastResponse = null;
+            for (WebhookCallback callback : endpointWebhook.getCallbacks()) {
+                lastResponse = callback.call(response);
+            }
+            return lastResponse;
+        }
+
+        return null;
+    }
+}

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/WebhookRestController.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/WebhookRestController.java
@@ -1,6 +1,7 @@
 package pl.consdata.ico.sqcompanion.hook;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,15 +12,17 @@ import pl.consdata.ico.sqcompanion.hook.callback.CallbackResponse;
 import pl.consdata.ico.sqcompanion.hook.callback.WebhookCallback;
 import pl.consdata.ico.sqcompanion.hook.trigger.RestWebhookTrigger;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/webhooks")
 public class WebhookRestController {
 
-    private List<Webhook> restWebhooks = new ArrayList<>();
+    private List<Webhook> restWebhooks;
     private WebhookActionDispatcher dispatcher;
 
     public WebhookRestController(WebhookService service, WebhookActionDispatcher dispatcher) {
@@ -27,20 +30,24 @@ public class WebhookRestController {
         this.dispatcher = dispatcher;
     }
 
+    private String getRandomCallbackIdIfNotSet(WebhookCallback callback) {
+        if (StringUtils.isBlank(callback.getId())) {
+            return UUID.randomUUID().toString();
+        } else {
+            return callback.getId();
+        }
+    }
+
     @RequestMapping(value = "/{endpoint}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public CallbackResponse get(@PathVariable String endpoint) {
+    public Map<String, CallbackResponse> get(@PathVariable String endpoint) {
         Webhook endpointWebhook = restWebhooks.stream().filter(webhook -> ((RestWebhookTrigger) webhook.getTrigger()).getMethod().equals("GET")
                 && ((RestWebhookTrigger) webhook.getTrigger()).getEndpoint().equals(endpoint)).findFirst().orElse(null);
         if (endpointWebhook != null) {
             ActionResponse response = dispatcher.dispatch(endpointWebhook);
 
-            // return last callback response as response for trigger
-            // its author responsibility to ensure that desired callback would be last in config
-            CallbackResponse lastResponse = null;
-            for (WebhookCallback callback : endpointWebhook.getCallbacks()) {
-                lastResponse = callback.call(response);
-            }
-            return lastResponse;
+            Map<String, CallbackResponse> callbackResponses = new HashMap<>();
+            endpointWebhook.getCallbacks().forEach(callback -> callbackResponses.put(getRandomCallbackIdIfNotSet(callback), callback.call(response)));
+            return callbackResponses;
         }
 
         return null;

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/WebhookRestController.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/WebhookRestController.java
@@ -22,10 +22,7 @@ public class WebhookRestController {
     private List<Webhook> restWebhooks = new ArrayList<>();
     private WebhookActionDispatcher dispatcher;
 
-    private WebhookService service;
-
     public WebhookRestController(WebhookService service, WebhookActionDispatcher dispatcher) {
-        this.service = service;
         restWebhooks = service.getAllWebhooksWithTrigger(RestWebhookTrigger.class);
         this.dispatcher = dispatcher;
     }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/WebhookService.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/WebhookService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import pl.consdata.ico.sqcompanion.config.AppConfig;
 import pl.consdata.ico.sqcompanion.config.GroupDefinition;
 import pl.consdata.ico.sqcompanion.config.WebhookDefinition;
+import pl.consdata.ico.sqcompanion.hook.callback.WebhookCallback;
 import pl.consdata.ico.sqcompanion.hook.trigger.WebhookTrigger;
 
 import java.util.ArrayList;

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/WebhookService.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/WebhookService.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service;
 import pl.consdata.ico.sqcompanion.config.AppConfig;
 import pl.consdata.ico.sqcompanion.config.GroupDefinition;
 import pl.consdata.ico.sqcompanion.config.WebhookDefinition;
-import pl.consdata.ico.sqcompanion.hook.callback.WebhookCallback;
 import pl.consdata.ico.sqcompanion.hook.trigger.WebhookTrigger;
 
 import java.util.ArrayList;

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/action/ActionResponse.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/action/ActionResponse.java
@@ -9,7 +9,6 @@ import java.util.Map;
 @Data
 @Builder
 public class ActionResponse {
-    private Map<String, String> group = new HashMap<>();
-    private Map<String, Map<String, String>> projects = new HashMap<>();
+    private Map<String, String> values = new HashMap<>();
     private String actionResult;
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/action/NoImprovementWebhookAction.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/action/NoImprovementWebhookAction.java
@@ -33,7 +33,7 @@ public class NoImprovementWebhookAction implements WebhookAction<NoImprovementWe
     }
 
     private boolean isGroupClean(Group group, NoImprovementWebhookActionData actionData) {
-        GroupViolationsHistoryDiff violationsHistoryDiff = violationsHistoryService.getGroupViolationsHistoryDiff(group, LocalDate.of(2018, 1, 20), LocalDate.of(2018, 1, 23));
+        GroupViolationsHistoryDiff violationsHistoryDiff = violationsHistoryService.getGroupViolationsHistoryDiff(group, LocalDate.ofEpochDay(0), LocalDate.now());
         return countDiff(violationsHistoryDiff, actionData) == 0;
     }
 
@@ -42,7 +42,7 @@ public class NoImprovementWebhookAction implements WebhookAction<NoImprovementWe
             return createResponse("clean", null);
         }
 
-        GroupViolationsHistoryDiff violationsHistoryDiff = violationsHistoryService.getGroupViolationsHistoryDiff(group, LocalDate.of(2018, 1, 20), LocalDate.of(2018, 1, 23));
+        GroupViolationsHistoryDiff violationsHistoryDiff = violationsHistoryService.getGroupViolationsHistoryDiff(group, LocalDate.now().minusDays(1), LocalDate.now());
         if (groupWasImproved(violationsHistoryDiff, actionData)) {
             return createResponse("improvement", countDiff(violationsHistoryDiff, actionData));
         } else {

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/callback/CallbackResponse.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/callback/CallbackResponse.java
@@ -1,0 +1,11 @@
+package pl.consdata.ico.sqcompanion.hook.callback;
+
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CallbackResponse {
+    private String text;
+}

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/callback/JSONWebhookCallback.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/callback/JSONWebhookCallback.java
@@ -1,0 +1,19 @@
+package pl.consdata.ico.sqcompanion.hook.callback;
+
+import lombok.Data;
+import pl.consdata.ico.sqcompanion.hook.action.ActionResponse;
+
+import java.util.Map;
+
+import static pl.consdata.ico.sqcompanion.hook.util.ResolveVariables.resolveVariables;
+
+@Data
+public class JSONWebhookCallback implements WebhookCallback {
+    private Map<String, String> body;
+
+    @Override
+    public CallbackResponse call(ActionResponse response) {
+        return CallbackResponse.builder().text(resolveVariables(response, body.get(response.getActionResult()))).build();
+    }
+
+}

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/callback/JSONWebhookCallback.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/callback/JSONWebhookCallback.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import static pl.consdata.ico.sqcompanion.hook.util.ResolveVariables.resolveVariables;
 
 @Data
-public class JSONWebhookCallback implements WebhookCallback {
+public class JSONWebhookCallback extends WebhookCallback {
     private Map<String, String> body;
 
     @Override

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/callback/PostWebhookCallback.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/callback/PostWebhookCallback.java
@@ -14,7 +14,7 @@ import static pl.consdata.ico.sqcompanion.hook.util.ResolveVariables.resolveVari
 
 @Slf4j
 @Data
-public class PostWebhookCallback implements WebhookCallback {
+public class PostWebhookCallback extends WebhookCallback {
     private Map<String, String> body;
     private String url;
 

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/callback/PostWebhookCallback.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/callback/PostWebhookCallback.java
@@ -2,12 +2,15 @@ package pl.consdata.ico.sqcompanion.hook.callback;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 import pl.consdata.ico.sqcompanion.hook.action.ActionResponse;
 
 import java.nio.charset.Charset;
 import java.util.Map;
+
+import static pl.consdata.ico.sqcompanion.hook.util.ResolveVariables.resolveVariables;
 
 @Slf4j
 @Data
@@ -17,18 +20,21 @@ public class PostWebhookCallback implements WebhookCallback {
 
     private RestTemplate restTemplate = new RestTemplate();
 
-    public PostWebhookCallback(){
+    public PostWebhookCallback() {
         restTemplate.getMessageConverters()
                 .add(0, new StringHttpMessageConverter(Charset.forName("UTF-8")));
     }
+
     @Override
-    public void call(ActionResponse response) {
+    public CallbackResponse call(ActionResponse response) {
         if (response != null) {
             if (body.containsKey(response.getActionResult())) {
-                restTemplate.postForLocation(url, body.get(response.getActionResult()));
+                restTemplate.postForLocation(url, resolveVariables(response, body.get(response.getActionResult())));
             } else {
                 log.warn("Invalid response");
             }
+            return CallbackResponse.builder().text(response.getActionResult()).build();
         }
+        return CallbackResponse.builder().text(StringUtils.EMPTY).build();
     }
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/callback/WebhookCallback.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/callback/WebhookCallback.java
@@ -10,7 +10,8 @@ import pl.consdata.ico.sqcompanion.hook.action.ActionResponse;
         property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = PostWebhookCallback.class, name = "POST"),
+        @JsonSubTypes.Type(value = JSONWebhookCallback.class, name = "JSON"),
 })
 public interface WebhookCallback {
-    void call(ActionResponse response);
+    CallbackResponse call(ActionResponse response);
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/callback/WebhookCallback.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/callback/WebhookCallback.java
@@ -2,6 +2,7 @@ package pl.consdata.ico.sqcompanion.hook.callback;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.Data;
 import pl.consdata.ico.sqcompanion.hook.action.ActionResponse;
 
 @JsonTypeInfo(
@@ -12,6 +13,8 @@ import pl.consdata.ico.sqcompanion.hook.action.ActionResponse;
         @JsonSubTypes.Type(value = PostWebhookCallback.class, name = "POST"),
         @JsonSubTypes.Type(value = JSONWebhookCallback.class, name = "JSON"),
 })
-public interface WebhookCallback {
-    CallbackResponse call(ActionResponse response);
+@Data
+public abstract class WebhookCallback {
+    private String id;
+    public abstract CallbackResponse call(ActionResponse response);
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/trigger/RestWebhookTrigger.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/trigger/RestWebhookTrigger.java
@@ -1,0 +1,9 @@
+package pl.consdata.ico.sqcompanion.hook.trigger;
+
+import lombok.Data;
+
+@Data
+public class RestWebhookTrigger implements WebhookTrigger {
+    private String method;
+    private String endpoint;
+}

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/trigger/WebhookTrigger.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/trigger/WebhookTrigger.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = CronWebhookTrigger.class, name = "CRON"),
+        @JsonSubTypes.Type(value = RestWebhookTrigger.class, name = "REST"),
 })
 public interface WebhookTrigger {
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/util/ResolveVariables.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/util/ResolveVariables.java
@@ -1,0 +1,13 @@
+package pl.consdata.ico.sqcompanion.hook.util;
+
+import pl.consdata.ico.sqcompanion.hook.action.ActionResponse;
+
+public final class ResolveVariables {
+    public static String resolveVariables(ActionResponse response, String source) {
+        String output = source;
+        for (String key : response.getValues().keySet()) {
+            output = output.replaceAll("\\$\\{\\s*" + key + "\\s*}", response.getValues().get(key));
+        }
+        return output;
+    }
+}


### PR DESCRIPTION
…ającego jsona. Dodanie możliwości paramtetryzowania odpowiedzi. Można teraz będzie zawołać akcję za pomocą geta na określonym w conifgu endpoincie. Np. dla settingsa endpoint: no_imp. Na serverze zostanie wystawiony endpoint /api/v1/webhooks/no_imp wołający określoną akcję. Uspójniłem wołanie callbacków. Każdy teraz zwraca obiekt typu CallbackResponse. Ostatni callback przekazuje swoją odpowiedź jako odpowiedź dla geta. Akcje mogą teraz zwracać mapę parametrów, które można użyć w konstruowaniu wiadomości. Np. akcja NO_IMPROVEMENT zwraca parametr diff - czyli różnicę miedzy liczbą wszystkich usuniętych i dodanych naruszeń. Przykładowo w callbacku można zwrócić: Poprawiliśmy ${diff} błędów.