### PR TITLE
Poprawka webhooka badającego poprawę w ilości naruszeń

### DIFF
--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/action/NoImprovementWebhookActionData.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/hook/action/NoImprovementWebhookActionData.java
@@ -9,10 +9,10 @@ import java.util.List;
 public class NoImprovementWebhookActionData extends WebhookActionData {
 
     @JsonProperty("period")
-    private Period period;
+    private String period;
     @JsonProperty("severity")
     private List<String> severity;
 
-    enum Period {DAILY}
+    enum Period {DAILY, WEEKLY, MONTHLY}
 
 }


### PR DESCRIPTION
Od teraz różnica wyliczana jest do dnia poprzedniego, a nie dnia w którym webhook został wywołany. Wiąże się to z tym, że po ostatnich zmianach analiza przeprowadzana jest do dnia poprzedniego licząc od momentu uruchomienie synchronizacji. Zakładam, że zmiana ta wynika z tego, że chcemy mieć analizę z pełnych dni?
Dodatkowo rozszerzyłem webhook o możliwość liczenia poprawy w ujęciu tygodniowym, miesięcznym i w wybranym okresie(np. 14d).