### PR TITLE
Poprawka pobierania memberów i unknown severity

### DIFF
--- a/sonarqube-companion-frontend/src/app/group/group-members.component.ts
+++ b/sonarqube-companion-frontend/src/app/group/group-members.component.ts
@@ -34,5 +34,4 @@ export class GroupMembersComponent {
       this.groupService.getGroupMembers(this.group.uuid).subscribe(data => this.members = data);
     }
   }
-
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/members/MemberService.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/members/MemberService.java
@@ -118,7 +118,7 @@ public class MemberService {
     }
 
     public List<Member> groupMembers(String groupId) {
-        return getAttachedMembers(membershipRepository.findByGroupIdAndDateIsLessThanEqualOrderByDateDesc(groupId, LocalDate.now()));
+        return getAttachedMembers(membershipRepository.findByGroupIdAndDateIsLessThanEqualOrderByDateDesc(groupId, LocalDate.now().minusDays(1)));
     }
 
     public List<Member> groupMembers(String groupId, LocalDate form, LocalDate to) {

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/sonarqube/RemoteSonarQubeFacade.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/sonarqube/RemoteSonarQubeFacade.java
@@ -12,6 +12,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static java.util.Optional.ofNullable;
+
 /**
  * @author gregorry
  */
@@ -153,7 +155,9 @@ public class RemoteSonarQubeFacade implements SonarQubeFacade {
     }
 
     private SonarQubeIssueSeverity asSeveriyt(SQIssue sqIssue) {
-        return SonarQubeIssueSeverity.valueOf(sqIssue.getSeverity());
+        return ofNullable(sqIssue.getSeverity())
+                .map(SonarQubeIssueSeverity::valueOf)
+                .orElse(SonarQubeIssueSeverity.UNKNOWN);
     }
 
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/sonarqube/SonarQubeIssueSeverity.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/sonarqube/SonarQubeIssueSeverity.java
@@ -5,5 +5,6 @@ public enum SonarQubeIssueSeverity {
     CRITICAL,
     MAJOR,
     MINOR,
-    INFO
+    INFO,
+    UNKNOWN
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/user/diff/UserProjectViolationDiffHistoryEntry.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/user/diff/UserProjectViolationDiffHistoryEntry.java
@@ -33,6 +33,7 @@ public class UserProjectViolationDiffHistoryEntry {
     private Integer majors;
     private Integer minors;
     private Integer infos;
+    private Integer unknown;
     private LocalDate date;
     @Column(columnDefinition = "VARCHAR(MAX)")
     private String issues;

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/user/diff/UserProjectViolationDiffHistoryEntry.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/user/diff/UserProjectViolationDiffHistoryEntry.java
@@ -33,7 +33,6 @@ public class UserProjectViolationDiffHistoryEntry {
     private Integer majors;
     private Integer minors;
     private Integer infos;
-    private Integer unknown;
     private LocalDate date;
     @Column(columnDefinition = "VARCHAR(MAX)")
     private String issues;

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/user/diff/UserViolationDiffSyncService.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/user/diff/UserViolationDiffSyncService.java
@@ -125,7 +125,6 @@ public class UserViolationDiffSyncService {
                     entry.setInfos(entry.getInfos() + 1);
                     break;
                 case UNKNOWN:
-                    entry.setUnknown(entry.getUnknown() + 1);
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown issue severity [" + issue.getSeverity() + "]");
@@ -149,8 +148,7 @@ public class UserViolationDiffSyncService {
                 .criticals(0)
                 .majors(0)
                 .minors(0)
-                .infos(0)
-                .unknown(0);
+                .infos(0);
     }
 
     private Map<LocalDate, List<SonarQubeIssue>> userIssuesAfterDate(final Project project, final SonarQubeUser user, final LocalDate syncDate) {

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/user/diff/UserViolationDiffSyncService.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/user/diff/UserViolationDiffSyncService.java
@@ -124,6 +124,9 @@ public class UserViolationDiffSyncService {
                 case INFO:
                     entry.setInfos(entry.getInfos() + 1);
                     break;
+                case UNKNOWN:
+                    entry.setUnknown(entry.getUnknown() + 1);
+                    break;
                 default:
                     throw new IllegalArgumentException("Unknown issue severity [" + issue.getSeverity() + "]");
             }
@@ -146,7 +149,8 @@ public class UserViolationDiffSyncService {
                 .criticals(0)
                 .majors(0)
                 .minors(0)
-                .infos(0);
+                .infos(0)
+                .unknown(0);
     }
 
     private Map<LocalDate, List<SonarQubeIssue>> userIssuesAfterDate(final Project project, final SonarQubeUser user, final LocalDate syncDate) {

--- a/sonarqube-companion-rest/src/test/java/pl/consdata/ico/sqcompanion/members/MemberServiceTest.java
+++ b/sonarqube-companion-rest/src/test/java/pl/consdata/ico/sqcompanion/members/MemberServiceTest.java
@@ -243,8 +243,8 @@ public class MemberServiceTest extends BaseItTest {
     }
 
     @Test
-    public void shouldReturnLatestAttachedMembers() {
-        //given
+    public void shouldReturnLatestAttachedMembersOnlyForCompletedDays() {
+        //given`
         MemberEntryEntity member = memberRepository.save(MemberEntryEntity.builder().id("member2").build());
         membershipRepository.save(MembershipEntryEntity.builder()
                 .groupId("group1")
@@ -258,7 +258,7 @@ public class MemberServiceTest extends BaseItTest {
         List<Member> members = memberService.groupMembers("group1");
 
         //then
-        assertThat(members).hasSize(2);
+        assertThat(members).hasSize(1);
     }
 
     @Test


### PR DESCRIPTION
- Górna granica wykresu to dzień poprzedni(bo dzisiejszy jeszcze nie jest kompletny). Jeśli wykres nie jest jeszcze zainicjowany to domyślnie jest strzał po wszystkich aktualnych memberów. Jeśli synchro było dzisiaj to występuje mrygnięcie. Najpierw strzał po wszystkich member X(dodany dzisiaj) jest, potem inicjalizacja wykresu i leci event od zmiany zakresu z końcową datą na wczoraj, przez co member X znika. Poprawka polega na obcięciu zakresu pobierania wszystkich memberów do dani poprzedniego
- Dodałem nowy poziom severity unknown, co by błędy nie leciały w logach jak severity przyjdzie puste. Niestety facet severities dla konkretnego usera zwraca tylko te znane, więc nie dodawałem kolejnych kategorii na froncie, bo info nie będzie kompletne.