### PR TITLE
New UI user groups aggregation

### DIFF
--- a/sonarqube-companion-frontend/angular.json
+++ b/sonarqube-companion-frontend/angular.json
@@ -55,7 +55,9 @@
               "apps/sonarqube-companion/src/favicon.ico",
               "apps/sonarqube-companion/src/assets"
             ],
-            "styles": ["apps/sonarqube-companion/src/styles.scss"],
+            "styles": [
+              "apps/sonarqube-companion/src/styles.scss"
+            ],
             "scripts": []
           },
           "configurations": {
@@ -399,6 +401,106 @@
             "lintFilePatterns": [
               "libs/ui-components/side-groups-tree/src/**/*.ts",
               "libs/ui-components/side-groups-tree/src/**/*.html"
+            ]
+          }
+        }
+      }
+    },
+    "ui-components-table": {
+      "projectType": "library",
+      "root": "libs/ui-components/table",
+      "sourceRoot": "libs/ui-components/table/src",
+      "prefix": "sonarqube-companion-frontend",
+      "architect": {
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/ui-components/table"],
+          "options": {
+            "jestConfig": "libs/ui-components/table/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": [
+              "libs/ui-components/table/src/**/*.ts",
+              "libs/ui-components/table/src/**/*.html"
+            ]
+          }
+        }
+      }
+    },
+    "project": {
+      "projectType": "library",
+      "root": "libs/project",
+      "sourceRoot": "libs/project/src",
+      "prefix": "sonarqube-companion-frontend",
+      "architect": {
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/project"],
+          "options": {
+            "jestConfig": "libs/project/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": [
+              "libs/project/src/**/*.ts",
+              "libs/project/src/**/*.html"
+            ]
+          }
+        }
+      }
+    },
+    "member": {
+      "projectType": "library",
+      "root": "libs/member",
+      "sourceRoot": "libs/member/src",
+      "prefix": "sonarqube-companion-frontend",
+      "architect": {
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/member"],
+          "options": {
+            "jestConfig": "libs/member/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": [
+              "libs/member/src/**/*.ts",
+              "libs/member/src/**/*.html"
+            ]
+          }
+        }
+      }
+    },
+    "ui-components-select": {
+      "projectType": "library",
+      "root": "libs/ui-components/select",
+      "sourceRoot": "libs/ui-components/select/src",
+      "prefix": "sonarqube-companion-frontend",
+      "architect": {
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/ui-components/select"],
+          "options": {
+            "jestConfig": "libs/ui-components/select/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": [
+              "libs/ui-components/select/src/**/*.ts",
+              "libs/ui-components/select/src/**/*.html"
             ]
           }
         }

--- a/sonarqube-companion-frontend/apps/sonarqube-companion/src/styles.scss
+++ b/sonarqube-companion-frontend/apps/sonarqube-companion/src/styles.scss
@@ -37,3 +37,23 @@ $sonarqube-companion-theme: mat.define-light-theme((
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+
+
+
+::-webkit-scrollbar {
+  width: 5px;
+}
+
+::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #888;
+  border-radius: 2px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #555;
+  border-radius: 2px;
+}

--- a/sonarqube-companion-frontend/jest.config.js
+++ b/sonarqube-companion-frontend/jest.config.js
@@ -11,5 +11,9 @@ module.exports = {
     '<rootDir>/libs/group',
     '<rootDir>/libs/sidenav',
     '<rootDir>/libs/ui-components/side-groups-tree',
+    '<rootDir>/libs/ui-components/table',
+    '<rootDir>/libs/project',
+    '<rootDir>/libs/member',
+    '<rootDir>/libs/ui-components/select',
   ],
 };

--- a/sonarqube-companion-frontend/libs/group-overview/src/index.ts
+++ b/sonarqube-companion-frontend/libs/group-overview/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/group-overview.module';
 export * from './lib/group-overview'
+export * from './lib/group-light-model'

--- a/sonarqube-companion-frontend/libs/group-overview/src/lib/group-light-model.ts
+++ b/sonarqube-companion-frontend/libs/group-overview/src/lib/group-light-model.ts
@@ -1,0 +1,5 @@
+export interface GroupLightModel {
+  name: string;
+  uuid: string;
+  groups: GroupLightModel[];
+}

--- a/sonarqube-companion-frontend/libs/group-overview/src/lib/group-overview.component.scss
+++ b/sonarqube-companion-frontend/libs/group-overview/src/lib/group-overview.component.scss
@@ -1,9 +1,21 @@
+@import "libs/ui-theme/src/palette";
+@import "libs/ui-theme/src/guidline";
+
 .group {
-  padding: 20px;
-  width: 90%;
+  width: 100%;
+  height: 100%;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
+  flex-direction: column;
+}
+
+.overview {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   flex-direction: column;
 }
 
@@ -21,9 +33,26 @@ sqc-value-badge {
   margin: 10px;
 }
 
+.header-container {
+  width: 100%;
+}
+
 .header {
-  font-size: 30px;
-  margin-bottom: 20px;
+  height: $top-bar-height;
+  min-height: $top-bar-height;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 600;
+  font-size: 20px;
+
+  .more {
+    right: 0;
+    position: absolute;
+    cursor: pointer;
+    display: flex;
+  }
 }
 
 .stats {
@@ -38,4 +67,84 @@ sqc-value-badge {
 .timeline {
   margin-bottom: 30px;
   width: 100%;
+}
+
+.values {
+  display: flex;
+  justify-content: center;
+  max-height: 20%;
+}
+
+.top-bar-divider {
+  width: 100%;
+}
+
+.timeline {
+  width: 100%;
+  min-height: 60%;
+  margin-bottom: 20px;
+}
+
+.tables {
+  display: flex;
+  width: 100%;
+  max-height: 40%;
+
+  .members {
+    width: 50%;
+    overflow: auto;
+    margin: 10px;
+  }
+
+  .projects {
+    width: 50%;
+    overflow: auto;
+    margin: 10px;
+    height: 100%;
+
+  }
+}
+
+.projects-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  .label {
+    margin-right: 10px;
+  }
+}
+
+.example-sidenav {
+  width: 100%;
+  background-color: map-get($primary-palette, 50);
+}
+
+.mat-drawer-content {
+  width: 100%;
+}
+
+.wrapper {
+  width: 100%;
+  height: 100%;
+}
+
+mat-drawer-container{
+  width: 100%;
+  height: 100%;
+}
+
+.filters {
+  margin-left: 20px;
+  margin-top: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  > * {
+    margin-right: 20px;
+  }
+}
+
+.footer {
+  height: 100px;
 }

--- a/sonarqube-companion-frontend/libs/group-overview/src/lib/group-overview.component.ts
+++ b/sonarqube-companion-frontend/libs/group-overview/src/lib/group-overview.component.ts
@@ -1,33 +1,140 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
-import {combineLatest, Observable, of} from 'rxjs';
+import {combineLatest, Observable} from 'rxjs';
 import {GroupDetails, GroupService} from '@sonarqube-companion-frontend/group';
 import {ActivatedRoute} from '@angular/router';
 import {distinctUntilChanged, map, switchMap} from 'rxjs/operators';
+import {GroupViolationsHistory} from '../../../group/src/lib/group-violations-history';
+import {Series} from '@swimlane/ngx-charts';
+import {ProjectViolationsHistoryDiff} from '@sonarqube-companion-frontend/project';
+import {ViolationsTableItem} from '../../../ui-components/table/src/lib/table/violations-table.component';
+import {Member, MemberViolationsHistoryDiff} from '@sonarqube-companion-frontend/member';
+import {SelectItem} from '@sonarqube-companion-frontend/ui-components/select';
+import {Violations} from '@sonarqube-companion-frontend/group-overview';
 
 interface GroupOverviewModel {
   details: GroupDetails;
+  violationsHistory: GroupViolationsHistory;
+  projectsDiff: ProjectViolationsHistoryDiff[];
+  membersDiff: MemberViolationsHistoryDiff[];
+  members: Member[];
+  violations: Violations;
 }
 
+// TODO pociąć ###################SDJLADSJDLKASJLKDJASLDJLKASJDLAKJSDLKSAJKLDJASLDJLAKSJDLKASJDLASJDLJAS <+++++++++++++++++++++++++++++++
 @Component({
   selector: 'sqc-group-overview',
   template: `
-    <div class="group" *ngIf="vm$ | async as vm">
-      {{vm.details.name}}
+    <div class="wrapper" *ngIf="vm$ | async as vm">
+      <div class="header-container">
+        <div class="header">
+          <div class="label">{{vm.details.name}}</div>
+          <div class="more" *ngIf="!drawer.opened">
+            <mat-divider vertical></mat-divider>
+            <button mat-button (click)="drawerSelector='projects'; drawer.toggle()" matTooltip="Projects">
+              <div class="projects-button">
+                <span class="label">{{vm.details.projects}}</span>
+                <mat-icon class="settings">code</mat-icon>
+              </div>
+            </button>
+            <mat-divider vertical></mat-divider>
+            <button mat-button (click)="drawerSelector='members'; drawer.toggle()" matTooltip="Members">
+              <div class="projects-button">
+                <span class="label">{{vm.details.members}}</span>
+                <mat-icon class="settings">group</mat-icon>
+              </div>
+            </button>
+            <mat-divider vertical></mat-divider>
+            <button mat-button (click)="drawerSelector='events'; drawer.toggle()" matTooltip="Events">
+              <div class="projects-button">
+                <span class="label">{{vm.details.events}}</span>
+                <mat-icon class="settings">event</mat-icon>
+              </div>
+            </button>
+          </div>
+          <div class="more" *ngIf="drawer.opened">
+            <mat-divider vertical></mat-divider>
+            <button mat-button (click)="drawerSelector=''; drawer.toggle()">
+              <div class="projects-button">
+                <mat-icon class="settings">close</mat-icon>
+              </div>
+            </button>
+          </div>
+        </div>
+        <mat-divider class="top-bar-divider"></mat-divider>
+      </div>
+      <div class="group">
+        <mat-drawer-container autosize [hasBackdrop]="false">
+          <mat-drawer #drawer class="example-sidenav" mode="over" position="end">
+
+            <div class="projects" *ngIf="drawerSelector === 'projects'">
+              <sqc-violations-table [nameAlias]="'Project'"
+                                    [data]="asViolationsTableItems(vm.projectsDiff)"></sqc-violations-table>
+            </div>
+            <div class="members" *ngIf="drawerSelector === 'members'">
+              <sqc-violations-table [nameAlias]="'Member'"
+                                    [data]="membersDiffAsViolationsTableItems(vm.membersDiff)"></sqc-violations-table>
+            </div>
+            <div class="events" *ngIf="drawerSelector === 'events'">
+              <sqc-violations-table [nameAlias]="'Member'"
+                                    [data]="membersDiffAsViolationsTableItems(vm.membersDiff)"></sqc-violations-table>
+            </div>
+          </mat-drawer>
+          <div class="overview">
+            <div class="values">
+              <sqc-value-badge [priority]="'urgent'" [label]="'blockers'" >{{vm.violations.blockers}}</sqc-value-badge>
+              <sqc-value-badge [priority]="'warning'"
+                               [label]="'criticals'">{{vm.violations.criticals}}</sqc-value-badge>
+              <sqc-value-badge [priority]="''" [label]="'majors'">{{vm.violations.majors}}</sqc-value-badge>
+              <sqc-value-badge [priority]="''" [label]="'minors'">{{vm.violations.minors}}</sqc-value-badge>
+              <sqc-value-badge [priority]="''" [label]="'infos'">{{vm.violations.infos}}</sqc-value-badge>
+            </div>
+            <div class="timeline">
+              <mat-divider></mat-divider>
+              <div class="filters">
+                <sqc-select [text]="'severity'" [items]="[]"></sqc-select>
+                <sqc-select [text]="'project'" [items]="[]"></sqc-select>
+                <sqc-select [text]="'member'" [items]="membersAsSelectItems(vm.members)"></sqc-select>
+              </div>
+              <sqc-timeline [data]="asSeries(vm.violationsHistory)"></sqc-timeline>
+            </div>
+            <div class="footer"></div>
+          </div>
+
+        </mat-drawer-container>
+      </div>
     </div>
   `,
   styleUrls: ['./group-overview.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class GroupOverviewComponent {
-
+  drawerSelector: string = ''
   vm$: Observable<GroupOverviewModel> = this.route.params.pipe(
     map(params => params['groupId']),
     distinctUntilChanged(),
     switchMap(id =>
       combineLatest([
-        this.groupService.groupDetails(id)
+        this.groupService.groupDetails(id),
+        this.groupService.groupViolationsHistory(id, 30),
+        this.groupService.groupProjectsHistoryDiff(id, 30),
+        this.groupService.groupMembersHistoryDiff(id, 30),
+        this.groupService.members(id),
+        this.groupService.violations(id),
       ]).pipe(
-        map(([details]) => ({details: details}))
+        map(([details,
+               violationsHistory,
+               projectsDiff,
+               membersDiff,
+               members,
+               violations
+             ]) => ({
+          details: details,
+          violationsHistory: violationsHistory,
+          projectsDiff: projectsDiff,
+          membersDiff: membersDiff,
+          members: members,
+          violations: violations
+        }))
       )
     )
   );
@@ -35,4 +142,51 @@ export class GroupOverviewComponent {
   constructor(private groupService: GroupService, private route: ActivatedRoute) {
   }
 
+  membersAsSelectItems(members: Member[]): SelectItem[] {
+    if (members) {
+      return members.map(item => ({id: item.uuid, text: `${item.firstName} ${item.lastName}`}));
+    } else {
+      return [];
+    }
+  }
+
+  asViolationsTableItems(projectsHistory: ProjectViolationsHistoryDiff[]): ViolationsTableItem[] {
+    return projectsHistory.map(entry => ({
+      uuid: entry.projectKey,
+      name: entry.projectKey,
+      blockers: {count: entry.violationsDiff.blockers, diff: 0},
+      criticals: {count: entry.violationsDiff.criticals, diff: 0},
+      majors: {count: entry.violationsDiff.majors, diff: 0},
+      minors: {count: entry.violationsDiff.minors, diff: 0},
+      infos: {count: entry.violationsDiff.infos, diff: 0},
+    }));
+  }
+
+  membersDiffAsViolationsTableItems(projectsHistory: MemberViolationsHistoryDiff[]): ViolationsTableItem[] {
+    return projectsHistory.map(entry => ({
+      uuid: entry.uuid,
+      name: entry.name,
+      blockers: {count: entry.violationsDiff.blockers, diff: 0},
+      criticals: {count: entry.violationsDiff.criticals, diff: 0},
+      majors: {count: entry.violationsDiff.majors, diff: 0},
+      minors: {count: entry.violationsDiff.minors, diff: 0},
+      infos: {count: entry.violationsDiff.infos, diff: 0},
+    }));
+  }
+
+  asSeries(violationsHistory: GroupViolationsHistory): Series[] {
+    if (violationsHistory) {
+      return [{
+        name: 'terst',
+        series: violationsHistory.violationHistoryEntries.map(entry => ({
+          name: new Date(entry.dateString),
+          value: entry.violations.blockers + entry.violations.criticals + entry.violations.majors + entry.violations.minors + entry.violations.infos
+        }))
+      }]
+    }
+    return [{
+      name: 'terst',
+      series: []
+    }]
+  }
 }

--- a/sonarqube-companion-frontend/libs/group-overview/src/lib/group-overview.module.ts
+++ b/sonarqube-companion-frontend/libs/group-overview/src/lib/group-overview.module.ts
@@ -7,6 +7,12 @@ import {UiComponentsHeatmapModule} from '@sonarqube-companion-frontend/ui-compon
 import {UiComponentsTimelineModule} from '@sonarqube-companion-frontend/ui-components/timeline';
 import {groupOverviewRouting} from './group-overview.routing';
 import {RouterModule} from '@angular/router';
+import {MatIconModule} from '@angular/material/icon';
+import {UiComponentsTableModule} from '@sonarqube-companion-frontend/ui-components/table';
+import {MatButtonModule} from '@angular/material/button';
+import {MatSidenavModule} from '@angular/material/sidenav';
+import {UiComponentsSelectModule} from '@sonarqube-companion-frontend/ui-components/select';
+import {MatTooltipModule} from '@angular/material/tooltip';
 
 
 @NgModule({
@@ -16,7 +22,13 @@ import {RouterModule} from '@angular/router';
     MatDividerModule,
     UiComponentsValueBadgeModule,
     UiComponentsHeatmapModule,
-    UiComponentsTimelineModule
+    UiComponentsTimelineModule,
+    MatIconModule,
+    MatButtonModule,
+    MatSidenavModule,
+    UiComponentsTableModule,
+    UiComponentsSelectModule,
+    MatTooltipModule
   ],
   declarations: [
     GroupOverviewComponent

--- a/sonarqube-companion-frontend/libs/group/src/lib/group-details.ts
+++ b/sonarqube-companion-frontend/libs/group/src/lib/group-details.ts
@@ -1,4 +1,7 @@
 export interface GroupDetails {
   uuid: string;
   name: string;
+  projects: number;
+  members: number;
+  events: number;
 }

--- a/sonarqube-companion-frontend/libs/group/src/lib/group-violations-history.ts
+++ b/sonarqube-companion-frontend/libs/group/src/lib/group-violations-history.ts
@@ -14,3 +14,4 @@ export interface Violations {
   minors: number;
   infos: number;
 }
+

--- a/sonarqube-companion-frontend/libs/group/src/lib/group.service.ts
+++ b/sonarqube-companion-frontend/libs/group/src/lib/group.service.ts
@@ -3,7 +3,9 @@ import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {GroupViolationsHistory} from './group-violations-history';
 import {GroupDetails} from './group-details';
-
+import {ProjectViolationsHistoryDiff} from '@sonarqube-companion-frontend/project';
+import {Member, MemberViolationsHistoryDiff} from '@sonarqube-companion-frontend/member';
+import {Violations} from '@sonarqube-companion-frontend/group-overview';
 
 
 @Injectable({providedIn: 'root'})
@@ -12,10 +14,30 @@ export class GroupService {
   }
 
   public groupViolationsHistory(uuid: string, daysLimit: number): Observable<GroupViolationsHistory> {
-    return this.http.get<GroupViolationsHistory>(`/api/v1/violations/history/group/${uuid}`, {params: {daysLimit: daysLimit}});
+    return this.http.get<GroupViolationsHistory>(`/api/v1/violations/history/group/${uuid}`);
   }
 
   public groupDetails(uuid: string): Observable<GroupDetails> {
     return this.http.get<GroupDetails>(`/api/v1/groups/${uuid}`);
+  }
+
+  public groupProjectsHistoryDiffRange(uuid: string, fromDate: Date, toDate: Date): Observable<ProjectViolationsHistoryDiff[]> {
+    return this.http.get<ProjectViolationsHistoryDiff[]>(`/api/v1/groups/${uuid}/projects/${fromDate}/${toDate}`);
+  }
+
+  public groupProjectsHistoryDiff(uuid: string, daysLimit: number): Observable<ProjectViolationsHistoryDiff[]> {
+    return this.http.get<ProjectViolationsHistoryDiff[]>(`/api/v1/violations/history/group/${uuid}/projects`, {params: {daysLimit: daysLimit}});
+  }
+
+  public groupMembersHistoryDiff(uuid: string, daysLimit: number): Observable<MemberViolationsHistoryDiff[]> {
+    return this.http.get<MemberViolationsHistoryDiff[]>(`/api/v1/violations/history/group/${uuid}/members`, {params: {daysLimit: daysLimit}});
+  }
+
+  public members(uuid: string): Observable<Member[]> {
+    return this.http.get<Member[]>(`/api/v1/groups/${uuid}/members`);
+  }
+
+  public violations(uuid: string): Observable<Violations> {
+    return this.http.get<Violations>(`/api/v1/groups/${uuid}/violations`);
   }
 }

--- a/sonarqube-companion-frontend/libs/member/.eslintrc.json
+++ b/sonarqube-companion-frontend/libs/member/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "sonarqubeCompanionFrontend",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "sonarqube-companion-frontend",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/sonarqube-companion-frontend/libs/member/README.md
+++ b/sonarqube-companion-frontend/libs/member/README.md
@@ -1,0 +1,7 @@
+# member
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test member` to execute the unit tests.

--- a/sonarqube-companion-frontend/libs/member/jest.config.js
+++ b/sonarqube-companion-frontend/libs/member/jest.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  displayName: 'member',
+  preset: '../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+      astTransformers: {
+        before: [
+          'jest-preset-angular/build/InlineFilesTransformer',
+          'jest-preset-angular/build/StripStylesTransformer',
+        ],
+      },
+    },
+  },
+  coverageDirectory: '../../coverage/libs/member',
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/sonarqube-companion-frontend/libs/member/src/index.ts
+++ b/sonarqube-companion-frontend/libs/member/src/index.ts
@@ -1,0 +1,3 @@
+export * from './lib/member.module';
+export * from './lib/member-violations-history-diff'
+export * from './lib/member'

--- a/sonarqube-companion-frontend/libs/member/src/lib/member-violations-history-diff.ts
+++ b/sonarqube-companion-frontend/libs/member/src/lib/member-violations-history-diff.ts
@@ -1,0 +1,19 @@
+export interface MemberViolationsHistoryDiff {
+  uuid: string;
+  name: string;
+  violationsDiff: Violations;
+  addedViolations: Violations;
+  removedViolation: Violations;
+  fromDate: Date;
+  toDate: Date;
+}
+
+
+export interface Violations {
+  blockers: number;
+  criticals: number;
+  majors: number;
+  minors: number;
+  infos: number;
+}
+

--- a/sonarqube-companion-frontend/libs/member/src/lib/member.module.ts
+++ b/sonarqube-companion-frontend/libs/member/src/lib/member.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  imports: [CommonModule],
+})
+export class MemberModule {}

--- a/sonarqube-companion-frontend/libs/member/src/lib/member.ts
+++ b/sonarqube-companion-frontend/libs/member/src/lib/member.ts
@@ -1,0 +1,10 @@
+export interface Member {
+  firstName: string;
+  lastName: string;
+  mail: string;
+  uuid: string;
+  aliases: string[];
+  goups: string[];
+  remote: boolean;
+  remoteType: string;
+}

--- a/sonarqube-companion-frontend/libs/member/src/test-setup.ts
+++ b/sonarqube-companion-frontend/libs/member/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/sonarqube-companion-frontend/libs/member/tsconfig.json
+++ b/sonarqube-companion-frontend/libs/member/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/sonarqube-companion-frontend/libs/member/tsconfig.lib.json
+++ b/sonarqube-companion-frontend/libs/member/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "target": "es2015",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": ["dom", "es2018"]
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/sonarqube-companion-frontend/libs/member/tsconfig.spec.json
+++ b/sonarqube-companion-frontend/libs/member/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/sonarqube-companion-frontend/libs/overview/src/lib/overview.service.ts
+++ b/sonarqube-companion-frontend/libs/overview/src/lib/overview.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
-import {GroupOverview} from '@sonarqube-companion-frontend/group-overview';
+import {GroupLightModel, GroupOverview} from '@sonarqube-companion-frontend/group-overview';
 
 @Injectable({
   providedIn: 'root'
@@ -14,5 +14,9 @@ export class OverviewService {
 
   public overview(): Observable<GroupOverview> {
     return this.http.get<GroupOverview>(this.url);
+  }
+
+  public list(): Observable<GroupLightModel> {
+    return this.http.get<GroupLightModel>(`${this.url}/list`);
   }
 }

--- a/sonarqube-companion-frontend/libs/overview/src/lib/overview/overview.component.scss
+++ b/sonarqube-companion-frontend/libs/overview/src/lib/overview/overview.component.scss
@@ -33,3 +33,4 @@
 sqc-group-overview {
   width: 50%;
 }
+

--- a/sonarqube-companion-frontend/libs/project/.eslintrc.json
+++ b/sonarqube-companion-frontend/libs/project/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "sonarqubeCompanionFrontend",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "sonarqube-companion-frontend",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/sonarqube-companion-frontend/libs/project/README.md
+++ b/sonarqube-companion-frontend/libs/project/README.md
@@ -1,0 +1,7 @@
+# project
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test project` to execute the unit tests.

--- a/sonarqube-companion-frontend/libs/project/jest.config.js
+++ b/sonarqube-companion-frontend/libs/project/jest.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  displayName: 'project',
+  preset: '../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+      astTransformers: {
+        before: [
+          'jest-preset-angular/build/InlineFilesTransformer',
+          'jest-preset-angular/build/StripStylesTransformer',
+        ],
+      },
+    },
+  },
+  coverageDirectory: '../../coverage/libs/project',
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/sonarqube-companion-frontend/libs/project/src/index.ts
+++ b/sonarqube-companion-frontend/libs/project/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/project.module';
+export * from './lib/project-violations-history-diff'

--- a/sonarqube-companion-frontend/libs/project/src/lib/project-violations-history-diff.ts
+++ b/sonarqube-companion-frontend/libs/project/src/lib/project-violations-history-diff.ts
@@ -1,0 +1,18 @@
+export interface ProjectViolationsHistoryDiff {
+  projectKey: string;
+  violationsDiff: Violations;
+  addedViolations: Violations;
+  removedViolation: Violations;
+  fromDate: Date;
+  toDate: Date;
+}
+
+
+export interface Violations {
+  blockers: number;
+  criticals: number;
+  majors: number;
+  minors: number;
+  infos: number;
+}
+

--- a/sonarqube-companion-frontend/libs/project/src/lib/project.module.ts
+++ b/sonarqube-companion-frontend/libs/project/src/lib/project.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  imports: [CommonModule],
+})
+export class ProjectModule {}

--- a/sonarqube-companion-frontend/libs/project/src/test-setup.ts
+++ b/sonarqube-companion-frontend/libs/project/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/sonarqube-companion-frontend/libs/project/tsconfig.json
+++ b/sonarqube-companion-frontend/libs/project/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/sonarqube-companion-frontend/libs/project/tsconfig.lib.json
+++ b/sonarqube-companion-frontend/libs/project/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "target": "es2015",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": ["dom", "es2018"]
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/sonarqube-companion-frontend/libs/project/tsconfig.spec.json
+++ b/sonarqube-companion-frontend/libs/project/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/sonarqube-companion-frontend/libs/sidenav/src/lib/group-sidenav/group-sidenav.component.scss
+++ b/sonarqube-companion-frontend/libs/sidenav/src/lib/group-sidenav/group-sidenav.component.scss
@@ -55,7 +55,6 @@ mat-divider {
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-direction: column;
 
 }
 
@@ -95,3 +94,12 @@ mat-divider {
 .mat-list-base {
   padding-top: 0;
 }
+
+mat-sidenav-content {
+  overflow: hidden;
+}
+
+.bottom-list {
+  display: flex;
+}
+

--- a/sonarqube-companion-frontend/libs/sidenav/src/lib/group-sidenav/group-sidenav.component.ts
+++ b/sonarqube-companion-frontend/libs/sidenav/src/lib/group-sidenav/group-sidenav.component.ts
@@ -1,8 +1,7 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Observable} from 'rxjs';
-import {GroupOverview} from '@sonarqube-companion-frontend/group-overview';
+import {GroupLightModel} from '@sonarqube-companion-frontend/group-overview';
 import {OverviewService} from '../../../../overview/src/lib/overview.service';
-import {GroupsTreeItem} from '../../../../ui-components/side-groups-tree/src/lib/groups-tree-item';
 import {Router} from '@angular/router';
 
 @Component({
@@ -35,7 +34,12 @@ import {Router} from '@angular/router';
             </mat-list-item>
           </mat-nav-list>
           <div class="expander"></div>
-          <mat-nav-list>
+          <mat-nav-list class="bottom-list">
+            <mat-list-item>
+              <div class="item">
+                <mat-icon>settings</mat-icon>
+              </div>
+            </mat-list-item>
             <mat-list-item>
               <div class="item"><a class="git" href="https://github.com/Consdata/sonarqube-companion"
                                    target="_blank"></a></div>
@@ -58,12 +62,12 @@ import {Router} from '@angular/router';
 })
 export class GroupSidenavComponent {
 
-  rootGroup$: Observable<GroupOverview> = this.overviewService.overview();
+  rootGroup$: Observable<GroupLightModel> = this.overviewService.list();
 
   constructor(private overviewService: OverviewService, private router: Router) { // TODO rename to list service and add server impl
   }
 
-  onSelect(event: GroupsTreeItem) {
+  onSelect(event: GroupLightModel) {
     this.router.navigate(['group', event.uuid])
   }
 }

--- a/sonarqube-companion-frontend/libs/ui-components/select/.eslintrc.json
+++ b/sonarqube-companion-frontend/libs/ui-components/select/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "sonarqubeCompanionFrontend",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "sonarqube-companion-frontend",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/sonarqube-companion-frontend/libs/ui-components/select/README.md
+++ b/sonarqube-companion-frontend/libs/ui-components/select/README.md
@@ -1,0 +1,7 @@
+# ui-components-select
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test ui-components-select` to execute the unit tests.

--- a/sonarqube-companion-frontend/libs/ui-components/select/jest.config.js
+++ b/sonarqube-companion-frontend/libs/ui-components/select/jest.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  displayName: 'ui-components-select',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+      astTransformers: {
+        before: [
+          'jest-preset-angular/build/InlineFilesTransformer',
+          'jest-preset-angular/build/StripStylesTransformer',
+        ],
+      },
+    },
+  },
+  coverageDirectory: '../../../coverage/libs/ui-components/select',
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/sonarqube-companion-frontend/libs/ui-components/select/src/index.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/select/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/ui-components-select.module';
+export * from './lib/select/select-item';

--- a/sonarqube-companion-frontend/libs/ui-components/select/src/lib/select/select-item.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/select/src/lib/select/select-item.ts
@@ -1,0 +1,4 @@
+export interface SelectItem {
+  id: string;
+  text: string;
+}

--- a/sonarqube-companion-frontend/libs/ui-components/select/src/lib/select/select.component.scss
+++ b/sonarqube-companion-frontend/libs/ui-components/select/src/lib/select/select.component.scss
@@ -1,0 +1,29 @@
+@import "libs/ui-theme/src/palette";
+
+.select-button .mat-select {
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.select-button {
+  position: relative;
+  border: 2px solid map-get($primary-palette, 300);
+  border-radius: 15px;
+  background-color: map-get($primary-palette, 100);
+  display: flex;
+  align-items: center;
+}
+
+
+.dropdown-list {
+  width: auto;
+}
+
+.list-area {
+  display: flex;
+  flex-direction: column;
+}

--- a/sonarqube-companion-frontend/libs/ui-components/select/src/lib/select/select.component.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/select/src/lib/select/select.component.ts
@@ -1,0 +1,19 @@
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import {SelectItem} from './select-item';
+
+@Component({
+  selector: 'sqc-select',
+  template: `
+
+  `,
+  styleUrls: ['./select.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SelectComponent {
+  @Input()
+  items!: SelectItem[];
+  selected: SelectItem[] = [];
+  @Input()
+  text?: string;
+
+}

--- a/sonarqube-companion-frontend/libs/ui-components/select/src/lib/ui-components-select.module.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/select/src/lib/ui-components-select.module.ts
@@ -1,0 +1,28 @@
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {SelectComponent} from './select/select.component';
+import {MatSelectModule} from '@angular/material/select';
+import {MatIconModule} from '@angular/material/icon';
+import {MatButtonModule} from '@angular/material/button';
+import {MatBadgeModule} from '@angular/material/badge';
+import {FormsModule} from '@angular/forms';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MatSelectModule,
+    MatIconModule,
+    MatButtonModule,
+    MatBadgeModule,
+    FormsModule
+  ],
+  declarations: [
+    SelectComponent
+
+  ],
+  exports: [
+    SelectComponent
+  ]
+})
+export class UiComponentsSelectModule {
+}

--- a/sonarqube-companion-frontend/libs/ui-components/select/src/test-setup.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/select/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/sonarqube-companion-frontend/libs/ui-components/select/tsconfig.json
+++ b/sonarqube-companion-frontend/libs/ui-components/select/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/sonarqube-companion-frontend/libs/ui-components/select/tsconfig.lib.json
+++ b/sonarqube-companion-frontend/libs/ui-components/select/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "target": "es2015",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": ["dom", "es2018"]
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/sonarqube-companion-frontend/libs/ui-components/select/tsconfig.spec.json
+++ b/sonarqube-companion-frontend/libs/ui-components/select/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/sonarqube-companion-frontend/libs/ui-components/side-groups-tree/src/lib/groups-tree-item.component.scss
+++ b/sonarqube-companion-frontend/libs/ui-components/side-groups-tree/src/lib/groups-tree-item.component.scss
@@ -7,19 +7,6 @@
   color: map-get($primary-palette, 200);
 }
 
-.status-indicator {
-  width: 10px;
-  height: 10px;
-  min-width: 10px;
-  min-height: 10px;
-  border-radius: 5px;
-
-  &.UNHEALTHY {
-    background-color: map-get($warn-palette, 100);
-  }
-}
-
-
 .mat-list-item-content {
   padding-left: 0;
 }

--- a/sonarqube-companion-frontend/libs/ui-components/side-groups-tree/src/lib/groups-tree-item.component.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/side-groups-tree/src/lib/groups-tree-item.component.ts
@@ -1,5 +1,5 @@
 import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
-import {GroupsTreeItem} from './groups-tree-item';
+import {GroupLightModel} from '@sonarqube-companion-frontend/group-overview';
 
 @Component({
   selector: 'sqc-side-groups-tree-item',
@@ -8,7 +8,6 @@ import {GroupsTreeItem} from './groups-tree-item';
       <div class="item">
         {{item.name}}
       </div>
-      <div class="status-indicator" [ngClass]="item.healthStatus"></div>
     </mat-list-item>
   `,
   styleUrls: ['./groups-tree-item.component.scss'],
@@ -17,6 +16,6 @@ import {GroupsTreeItem} from './groups-tree-item';
 export class GroupsTreeItemComponent {
 
   @Input()
-  item!: GroupsTreeItem;
+  item!: GroupLightModel;
 
 }

--- a/sonarqube-companion-frontend/libs/ui-components/side-groups-tree/src/lib/groups-tree-item.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/side-groups-tree/src/lib/groups-tree-item.ts
@@ -1,6 +1,0 @@
-export interface GroupsTreeItem {
-  name: string;
-  uuid: string;
-  groups: GroupsTreeItem[];
-  healthStatus: string;
-}

--- a/sonarqube-companion-frontend/libs/ui-components/side-groups-tree/src/lib/groups-tree-wrapper.component.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/side-groups-tree/src/lib/groups-tree-wrapper.component.ts
@@ -1,6 +1,6 @@
 import {ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {Observable} from 'rxjs';
-import {GroupsTreeItem} from './groups-tree-item';
+import {GroupLightModel} from '@sonarqube-companion-frontend/group-overview';
 
 @Component({
   selector: 'sqc-side-groups-tree-wrapper',
@@ -22,9 +22,9 @@ import {GroupsTreeItem} from './groups-tree-item';
 export class GroupsTreeWrapperComponent {
 
   @Input('rootGroup')
-  rootGroup$!: Observable<GroupsTreeItem>;
+  rootGroup$!: Observable<GroupLightModel>;
 
   @Output()
-  groupSelect: EventEmitter<GroupsTreeItem> = new EventEmitter<GroupsTreeItem>();
+  groupSelect: EventEmitter<GroupLightModel> = new EventEmitter<GroupLightModel>();
 
 }

--- a/sonarqube-companion-frontend/libs/ui-components/side-groups-tree/src/lib/groups-tree.component.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/side-groups-tree/src/lib/groups-tree.component.ts
@@ -1,7 +1,7 @@
 import {ChangeDetectionStrategy, Component, EventEmitter, Input, Output} from '@angular/core';
 import {NestedTreeControl} from '@angular/cdk/tree';
 import {MatTreeNestedDataSource} from '@angular/material/tree';
-import {GroupsTreeItem} from './groups-tree-item';
+import {GroupLightModel} from '@sonarqube-companion-frontend/group-overview';
 
 @Component({
   selector: 'sqc-side-groups-tree',
@@ -31,19 +31,19 @@ import {GroupsTreeItem} from './groups-tree-item';
 })
 export class GroupsTreeComponent {
 
-  treeControl = new NestedTreeControl<GroupsTreeItem>(node => node.groups);
-  dataSource = new MatTreeNestedDataSource<GroupsTreeItem>();
+  treeControl = new NestedTreeControl<GroupLightModel>(node => node.groups);
+  dataSource = new MatTreeNestedDataSource<GroupLightModel>();
 
   @Output()
-  groupSelect: EventEmitter<GroupsTreeItem> = new EventEmitter<GroupsTreeItem>();
+  groupSelect: EventEmitter<GroupLightModel> = new EventEmitter<GroupLightModel>();
 
   constructor() {
   }
 
   @Input()
-  set rootGroup(rootGroup: GroupsTreeItem) {
+  set rootGroup(rootGroup: GroupLightModel) {
     this.dataSource.data = [rootGroup];
   }
 
-  hasChild = (_: number, node: GroupsTreeItem) => !!node.groups && node.groups.length > 0;
+  hasChild = (_: number, node: GroupLightModel) => !!node.groups && node.groups.length > 0;
 }

--- a/sonarqube-companion-frontend/libs/ui-components/table/.eslintrc.json
+++ b/sonarqube-companion-frontend/libs/ui-components/table/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "sonarqubeCompanionFrontend",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "sonarqube-companion-frontend",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/sonarqube-companion-frontend/libs/ui-components/table/README.md
+++ b/sonarqube-companion-frontend/libs/ui-components/table/README.md
@@ -1,0 +1,7 @@
+# ui-components-table
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test ui-components-table` to execute the unit tests.

--- a/sonarqube-companion-frontend/libs/ui-components/table/jest.config.js
+++ b/sonarqube-companion-frontend/libs/ui-components/table/jest.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  displayName: 'ui-components-table',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+      astTransformers: {
+        before: [
+          'jest-preset-angular/build/InlineFilesTransformer',
+          'jest-preset-angular/build/StripStylesTransformer',
+        ],
+      },
+    },
+  },
+  coverageDirectory: '../../../coverage/libs/ui-components/table',
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/sonarqube-companion-frontend/libs/ui-components/table/src/index.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/table/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/ui-components-table.module';

--- a/sonarqube-companion-frontend/libs/ui-components/table/src/lib/table/violations-table.component.scss
+++ b/sonarqube-companion-frontend/libs/ui-components/table/src/lib/table/violations-table.component.scss
@@ -1,0 +1,32 @@
+@import "libs/ui-theme/src/palette";
+
+table {
+  width: 100%;
+  background-color: map-get($primary-palette, 50);
+  height: 100%;
+}
+
+th.mat-sort-header-sorted {
+  color: black;
+}
+
+.table-container {
+  position: relative;
+  overflow: auto;
+}
+
+.mat-form-field {
+  font-size: 14px;
+  width: 100%;
+}
+
+.search {
+  display: flex;
+  align-items: center;
+  padding-left: 20px;
+  padding-right: 20px;
+
+  .icon {
+    margin-right: 10px;
+  }
+}

--- a/sonarqube-companion-frontend/libs/ui-components/table/src/lib/table/violations-table.component.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/table/src/lib/table/violations-table.component.ts
@@ -1,0 +1,102 @@
+import {Component, Input, ViewChild} from '@angular/core';
+import {MatTableDataSource} from '@angular/material/table';
+import {MatSort} from '@angular/material/sort';
+
+export interface ViolationTableItem {
+  count: number;
+  diff: number;
+}
+
+export interface ViolationsTableItem {
+  uuid: string;
+  name: string;
+  blockers: ViolationTableItem;
+  criticals: ViolationTableItem;
+  majors: ViolationTableItem;
+  minors: ViolationTableItem;
+  infos: ViolationTableItem;
+}
+
+@Component({
+  selector: 'sqc-violations-table',
+  template: `
+
+    <div class="search">
+      <mat-icon class="icon">search</mat-icon>
+      <mat-form-field appearance="standard">
+        <input matInput (keyup)="applyFilter($event)" #input>
+      </mat-form-field>
+    </div>
+
+    <table mat-table [dataSource]="dataSource" class="sqc-table" *ngIf="_data" matSort>
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header> {{nameAlias ? nameAlias : 'Name'}} </th>
+        <td mat-cell *matCellDef="let element"> {{element.name}} </td>
+      </ng-container>
+
+      <ng-container matColumnDef="blockers">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Blockers</th>
+        <td mat-cell *matCellDef="let element"> {{element.blockers.count}} </td>
+      </ng-container>
+
+      <ng-container matColumnDef="criticals">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Criticals</th>
+        <td mat-cell *matCellDef="let element"> {{element.criticals.count}} </td>
+      </ng-container>
+
+      <ng-container matColumnDef="majors">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header> Majors</th>
+        <td mat-cell
+            *matCellDef="let element"> {{element.majors.count}} </td>
+      </ng-container>
+
+
+      <ng-container matColumnDef="minors">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Minors</th>
+        <td mat-cell
+            *matCellDef="let element"> {{element.minors.count}} </td>
+      </ng-container>
+
+
+      <ng-container matColumnDef="infos">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Infos</th>
+        <td mat-cell
+            *matCellDef="let element"> {{element.infos.count}} </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;">
+      </tr>
+
+      <tr class="mat-row" *matNoDataRow>
+        <td class="mat-cell" colspan="4">No data matching the filter "{{input.value}}"</td>
+      </tr>
+    </table>
+  `,
+  styleUrls: ['./violations-table.component.scss']
+})
+export class ViolationsTableComponent {
+
+  displayedColumns: string[] = ['name', 'blockers', 'criticals', 'majors', 'minors', 'infos'];
+  dataSource!: MatTableDataSource<ViolationsTableItem>
+  @Input()
+  nameAlias?: string;
+  @ViewChild(MatSort) sort!: MatSort;
+
+  _data?: ViolationsTableItem[];
+
+  @Input()
+  set data(violations: ViolationsTableItem[]) {
+    this._data = violations;
+    this.dataSource = new MatTableDataSource<ViolationsTableItem>(violations);
+    this.dataSource.sort = this.sort;
+    this.dataSource.filterPredicate = (data: ViolationsTableItem, filter: string) => {
+      return data.name.includes(filter);
+    };
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+  }
+}

--- a/sonarqube-companion-frontend/libs/ui-components/table/src/lib/ui-components-table.module.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/table/src/lib/ui-components-table.module.ts
@@ -1,0 +1,29 @@
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {ViolationsTableComponent} from './table/violations-table.component';
+import {MatTableModule} from '@angular/material/table';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatSortModule} from '@angular/material/sort';
+import {MatIconModule} from '@angular/material/icon';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatCheckboxModule,
+    MatSortModule,
+    MatIconModule,
+    MatFormFieldModule,
+    MatInputModule
+  ],
+  declarations: [
+    ViolationsTableComponent
+  ],
+  exports: [
+    ViolationsTableComponent
+  ]
+})
+export class UiComponentsTableModule {
+}

--- a/sonarqube-companion-frontend/libs/ui-components/table/src/test-setup.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/table/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/sonarqube-companion-frontend/libs/ui-components/table/tsconfig.json
+++ b/sonarqube-companion-frontend/libs/ui-components/table/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/sonarqube-companion-frontend/libs/ui-components/table/tsconfig.lib.json
+++ b/sonarqube-companion-frontend/libs/ui-components/table/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "target": "es2015",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": ["dom", "es2018"]
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/sonarqube-companion-frontend/libs/ui-components/table/tsconfig.spec.json
+++ b/sonarqube-companion-frontend/libs/ui-components/table/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/sonarqube-companion-frontend/libs/ui-components/timeline/src/lib/timeline.component.scss
+++ b/sonarqube-companion-frontend/libs/ui-components/timeline/src/lib/timeline.component.scss
@@ -1,8 +1,10 @@
 :host {
-  display: block;
+  height: 100%;
+  width: 100%;
 }
 
 .wrapper {
-  height: 200px;
+  height: 100%;
   width: 100%;
 }
+

--- a/sonarqube-companion-frontend/libs/ui-components/timeline/src/lib/timeline.component.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/timeline/src/lib/timeline.component.ts
@@ -5,10 +5,10 @@ import {curveBasis, CurveFactory} from 'd3-shape';
 @Component({
   selector: 'sqc-timeline',
   template: `
-    <div class="wrapper">
+    <div class="wrapper" *ngIf="data">
       <ngx-charts-line-chart
         [results]="data"
-        [timeline]="false"
+        [timeline]="true"
         [xAxis]="true"
         [yAxis]="true"
         [autoScale]="true"
@@ -23,12 +23,12 @@ import {curveBasis, CurveFactory} from 'd3-shape';
 export class TimelineComponent {
 
   @Input()
-  data!: Series[];
+  data?: Series[];
 
   curve: CurveFactory = curveBasis;
 
   onSelect(data: any): void {
-    //  console.log('Item clicked', JSON.parse(JSON.stringify(data)));
+
   }
 
   onActivate(data: any): void {

--- a/sonarqube-companion-frontend/libs/ui-components/value-badge/src/lib/value-badge.component.scss
+++ b/sonarqube-companion-frontend/libs/ui-components/value-badge/src/lib/value-badge.component.scss
@@ -1,7 +1,7 @@
 @import "libs/ui-theme/src/palette";
 
 .content {
-  padding: 20px;
+  margin: auto;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -10,25 +10,30 @@
 
 
 .badge {
-  background-color: map-get($primary-palette, 200);
-  border-radius: 5px;
+  border-color: map-get($primary-palette, 400);
+  border-width: 5px;
+  border-style: solid;
+  border-radius: 50%;
   display: flex;
   align-items: center;
+  min-width: 50px;
+  min-height: 50px;
+  padding: 10px;
 }
 
 
 .value {
-  font-size: 24px;
+  font-weight: 600;
 }
 
 .label {
-  font-size: 10px;
+  font-size: 14px;
 }
 
 .urgent {
-  background-color: #f3c5c5;
+  border-color: #f3b0b0;
 }
 
 .warning {
-  background-color: #f3edc5;
+  border-color: #f3e9a4;
 }

--- a/sonarqube-companion-frontend/libs/ui-components/value-badge/src/lib/value-badge.component.ts
+++ b/sonarqube-companion-frontend/libs/ui-components/value-badge/src/lib/value-badge.component.ts
@@ -9,8 +9,8 @@ import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
           <ng-content></ng-content>
         </div>
         <span class="label">{{label}}</span>
+        <mat-icon *ngIf="icon">{{icon}}</mat-icon>
       </div>
-      <mat-icon *ngIf="icon">{{icon}}</mat-icon>
     </div>
   `,
   styleUrls: ['./value-badge.component.scss'],

--- a/sonarqube-companion-frontend/nx.json
+++ b/sonarqube-companion-frontend/nx.json
@@ -55,6 +55,18 @@
     },
     "ui-components-side-groups-tree": {
       "tags": []
+    },
+    "ui-components-table": {
+      "tags": []
+    },
+    "project": {
+      "tags": []
+    },
+    "member": {
+      "tags": []
+    },
+    "ui-components-select": {
+      "tags": []
     }
   }
 }

--- a/sonarqube-companion-frontend/tsconfig.base.json
+++ b/sonarqube-companion-frontend/tsconfig.base.json
@@ -36,6 +36,14 @@
       "@sonarqube-companion-frontend/sidenav": ["libs/sidenav/src/index.ts"],
       "@sonarqube-companion-frontend/ui-components/side-groups-tree": [
         "libs/ui-components/side-groups-tree/src/index.ts"
+      ],
+      "@sonarqube-companion-frontend/ui-components/table": [
+        "libs/ui-components/table/src/index.ts"
+      ],
+      "@sonarqube-companion-frontend/project": ["libs/project/src/index.ts"],
+      "@sonarqube-companion-frontend/member": ["libs/member/src/index.ts"],
+      "@sonarqube-companion-frontend/ui-components/select": [
+        "libs/ui-components/select/src/index.ts"
       ]
     }
   },

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/IndexHtmlController.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/IndexHtmlController.java
@@ -44,28 +44,10 @@ public class IndexHtmlController {
             final Document template = Jsoup.parse(indexInputStream, "UTF-8", "");
 
             baseHrefParam.ifPresent(baseHref -> appendBaseHref(template, baseHref));
-            appendAppConfig(template);
-
             return template.toString();
         } catch (IOException exception) {
             throw new SQCompanionException("Can't load index.html template", exception);
         }
-    }
-
-    private void appendAppConfig(Document template) throws JsonProcessingException {
-        final Map<String, Object> config = new HashMap<>();
-        config.put("random", 4);
-        template.getElementById("appServerDefaultConfig")
-                .after(
-                        new StringBuilder()
-                                .append("<script type=\"text/javascript\">")
-                                .append("window.serverAppConfig = window.serverAppConfig || {};")
-                                .append("Object.assign(window.serverAppConfig, ")
-                                .append(objectMapper.writeValueAsString(config))
-                                .append(");")
-                                .append("</script>")
-                                .toString()
-                );
     }
 
     private void appendBaseHref(final Document template, final String baseHref) {

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/cache/Caches.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/cache/Caches.java
@@ -17,7 +17,6 @@ public class Caches {
     public static final String PROJECT_VIOLATIONS_HISTORY_CACHE = "cache_project_violations_history";
     public static final String PROJECT_VIOLATIONS_HISTORY_DIFF_CACHE = "cache_project_violations_history_diff";
     public static final String GROUP_USER_VIOLATIONS_HISTORY_DIFF_CACHE = "cache_group_user_violations_history_diff";
-    public static final String GROUP_USERS_VIOLATIONS_HISTORY_DIFF_CACHE = "cache_group_users_violations_history_diff";
     public static final String GROUP_PROJECT_VIOLATIONS_HISTORY_CACHE = "cache_group_project_violations_history";
     public static final String GROUP_PROJECT_VIOLATIONS_HISTORY_DIFF_CACHE = "cache_group_project_violations_history_diff";
     public static final String GROUP_PROJECT_SUMMARY_CACHE = "cache_group_project_summary";
@@ -32,7 +31,6 @@ public class Caches {
             PROJECT_VIOLATIONS_HISTORY_CACHE,
             PROJECT_VIOLATIONS_HISTORY_DIFF_CACHE,
             GROUP_USER_VIOLATIONS_HISTORY_DIFF_CACHE,
-            GROUP_USERS_VIOLATIONS_HISTORY_DIFF_CACHE,
             GROUP_PROJECT_VIOLATIONS_HISTORY_CACHE,
             GROUP_PROJECT_VIOLATIONS_HISTORY_DIFF_CACHE,
             GROUP_PROJECT_SUMMARY_CACHE

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/config/model/GroupLightModel.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/config/model/GroupLightModel.java
@@ -4,6 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import pl.consdata.ico.sqcompanion.repository.Group;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
+import static java.util.Optional.ofNullable;
 
 @Data
 @Builder
@@ -12,11 +19,22 @@ import lombok.NoArgsConstructor;
 public class GroupLightModel {
     private String name;
     private String uuid;
+    private List<GroupLightModel> groups;
 
     public static GroupLightModel of(GroupDefinition group) {
         return GroupLightModel.builder()
                 .uuid(group.getUuid())
                 .name(group.getName())
+                .groups(ofNullable(group.getGroups()).orElse(emptyList()).stream().map(GroupLightModel::of).collect(Collectors.toList()))
                 .build();
     }
+
+    public static GroupLightModel of(Group group) {
+        return GroupLightModel.builder()
+                .uuid(group.getUuid())
+                .name(group.getName())
+                .groups(ofNullable(group.getGroups()).orElse(emptyList()).stream().map(GroupLightModel::of).collect(Collectors.toList()))
+                .build();
+    }
+
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/config/model/MembersDefinition.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/config/model/MembersDefinition.java
@@ -1,5 +1,6 @@
 package pl.consdata.ico.sqcompanion.config.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
 
 import java.util.ArrayList;
@@ -9,8 +10,8 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MembersDefinition {
     @Singular("local")
     private List<Member> local = new ArrayList<>();
-    private boolean recursive;
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/group/GroupController.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/group/GroupController.java
@@ -6,10 +6,12 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import pl.consdata.ico.sqcompanion.SQCompanionException;
+import pl.consdata.ico.sqcompanion.config.model.GroupLightModel;
 import pl.consdata.ico.sqcompanion.config.model.Member;
 import pl.consdata.ico.sqcompanion.members.MemberService;
 import pl.consdata.ico.sqcompanion.repository.Group;
 import pl.consdata.ico.sqcompanion.repository.RepositoryService;
+import pl.consdata.ico.sqcompanion.violation.Violations;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -41,6 +43,24 @@ public class GroupController {
     public GroupDetails getRootGroup() {
         return groupService.getRootGroupDetails();
     }
+
+    @GetMapping(
+            value = "/{uuid}/info",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @ApiOperation(
+            value = "Returns group basic data",
+            notes = "<p>Returns group basic data</p>"
+    )
+    public GroupLightModel info(@PathVariable final String uuid) {
+        final Optional<Group> group = repositoryService.getGroup(uuid);
+        if (group.isPresent()) {
+            return GroupLightModel.of(group.get());
+        } else {
+            throw new SQCompanionException("Can't find requested group uuid: " + uuid);
+        }
+    }
+
 
     @RequestMapping(
             value = "/{uuid}",
@@ -92,4 +112,24 @@ public class GroupController {
     public Set<Member> getMembers(@PathVariable final String uuid, @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from, @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
         return memberService.groupMembers(uuid, from, to);
     }
+
+
+    @GetMapping(
+            value = "/{uuid}/violations",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @ApiOperation(
+            value = "Returns group members between given period.",
+            notes = "<p>Returns group members</p>"
+    )
+    public Violations getViolations(@PathVariable final String uuid) {
+        final Optional<Group> group = repositoryService.getGroup(uuid);
+        if (group.isPresent()) {
+            return groupService.getViolations(group.get());
+        } else {
+            throw new SQCompanionException("Can't find requested group uuid: " + uuid);
+        }
+    }
+
+
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/group/GroupDetails.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/group/GroupDetails.java
@@ -24,10 +24,8 @@ public class GroupDetails {
     private String uuid;
     private String name;
     private HealthStatus healthStatus;
-    private Violations violations;
-    private List<GroupSummary> groups;
-    private List<ProjectSummary> projects;
-    private List<IssueSummary> issues;
-    private List<GroupEvent> events;
+    private Integer projects;
+    private Integer members;
+    private Integer events;
 
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/members/MemberService.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/members/MemberService.java
@@ -122,17 +122,13 @@ public class MemberService {
     }
 
     public Set<Member> groupMembers(String groupId) {
-        if (appConfig.getMembers().isRecursive()) {
-            return repositoryService.getGroup(groupId)
-                    .map(Group::getAllGroups)
-                    .orElse(Collections.emptyList())
-                    .stream()
-                    .map(group -> getAttachedMembers(membershipRepository.findByGroupIdAndDateIsLessThanEqualOrderByDateDesc(group.getUuid(), LocalDate.now().minusDays(1))))
-                    .flatMap(Set::stream)
-                    .collect(Collectors.toSet());
-        } else {
-            return getAttachedMembers(membershipRepository.findByGroupIdAndDateIsLessThanEqualOrderByDateDesc(groupId, LocalDate.now().minusDays(1)));
-        }
+        return repositoryService.getGroup(groupId)
+                .map(Group::getAllGroups)
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(group -> getAttachedMembers(membershipRepository.findByGroupIdAndDateIsLessThanEqualOrderByDateDesc(group.getUuid(), LocalDate.now().minusDays(1))))
+                .flatMap(Set::stream)
+                .collect(Collectors.toSet());
     }
 
     public Set<String> membersAliases(String groupId) {

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/members/MembersViolationsHistoryDiff.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/members/MembersViolationsHistoryDiff.java
@@ -1,0 +1,33 @@
+package pl.consdata.ico.sqcompanion.members;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import pl.consdata.ico.sqcompanion.violation.Violations;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MembersViolationsHistoryDiff {
+
+    private String uuid;
+    private String name;
+    private Violations violationsDiff;
+    private Violations addedViolations;
+    private Violations removedViolations;
+    private LocalDate fromDate;
+    private LocalDate toDate;
+
+    public String getFromDateString() {
+        return fromDate.toString();
+    }
+
+    public String getToDateString() {
+        return toDate.toString();
+    }
+
+}

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/overview/OverviewController.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/overview/OverviewController.java
@@ -5,6 +5,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import pl.consdata.ico.sqcompanion.config.model.GroupLightModel;
 import pl.consdata.ico.sqcompanion.repository.RepositoryService;
 
 @RestController
@@ -28,4 +29,12 @@ public class OverviewController {
         return overviewService.getOverview(repositoryService.getRootGroup());
     }
 
+    @GetMapping(value = "/list", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation(
+            value = "Returns organization structure",
+            notes = "<p>Returns groups tree with names.</p>"
+    )
+    public GroupLightModel getGroups() {
+        return overviewService.list(repositoryService.getRootGroup());
+    }
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/overview/OverviewService.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/overview/OverviewService.java
@@ -5,11 +5,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import pl.consdata.ico.sqcompanion.cache.Caches;
+import pl.consdata.ico.sqcompanion.config.model.GroupLightModel;
 import pl.consdata.ico.sqcompanion.health.HealthCheckService;
 import pl.consdata.ico.sqcompanion.health.HealthStatus;
 import pl.consdata.ico.sqcompanion.members.MemberService;
 import pl.consdata.ico.sqcompanion.project.ProjectSummary;
-import pl.consdata.ico.sqcompanion.project.ProjectSummaryService;
 import pl.consdata.ico.sqcompanion.repository.Group;
 import pl.consdata.ico.sqcompanion.violation.user.summary.UserViolationSummaryHistoryService;
 
@@ -48,4 +48,7 @@ public class OverviewService {
                 .build();
     }
 
+    public GroupLightModel list(Group rootGroup) {
+        return GroupLightModel.of(rootGroup);
+    }
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/repository/Group.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/repository/Group.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import pl.consdata.ico.sqcompanion.config.model.GroupEvent;
+import pl.consdata.ico.sqcompanion.config.model.GroupLightModel;
 
 import java.util.*;
 
@@ -16,6 +17,7 @@ public class Group {
 
     private String uuid;
     private String name;
+    private List<GroupLightModel> parentGroups;
     private List<Group> groups;
     private List<Project> projects;
     private List<GroupEvent> events;

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/sync/SynchronizationController.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/sync/SynchronizationController.java
@@ -1,6 +1,7 @@
 package pl.consdata.ico.sqcompanion.sync;
 
 import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,16 +14,12 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/sync")
+@RequiredArgsConstructor
 public class SynchronizationController {
 
     private final SynchronizationStateService synchronizationStateService;
     private final SynchronizationTrigger synchronizationTrigger;
 
-    public SynchronizationController(final SynchronizationStateService synchronizationStateService,
-                                     final SynchronizationTrigger synchronizationTrigger) {
-        this.synchronizationStateService = synchronizationStateService;
-        this.synchronizationTrigger = synchronizationTrigger;
-    }
 
     @RequestMapping(value = "/state", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/sync/SynchronizationService.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/sync/SynchronizationService.java
@@ -2,6 +2,7 @@ package pl.consdata.ico.sqcompanion.sync;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 import pl.consdata.ico.sqcompanion.cache.Caches;
@@ -68,11 +69,10 @@ public class SynchronizationService {
         userViolationDiffSyncService.sync();
         userViolationSummaryHistorySyncService.sync();
         synchronizationStateService.finishSynchronization();
-
         Caches.LIST
                 .stream()
                 .map(cacheManager::getCache)
-                .forEach(cache -> cache.clear());
+                .forEach(Cache::clear);
 
         log.info("Synchronization finished in {}ms", (System.currentTimeMillis() - startTime));
     }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/Violations.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/Violations.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import pl.consdata.ico.sqcompanion.violation.user.ViolationHistorySource;
+import pl.consdata.ico.sqcompanion.violation.user.ViolationSource;
 
 /**
  * @author gregorry
@@ -12,15 +14,15 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Violations {
+public class Violations implements ViolationSource {
 
-    private int blockers;
-    private int criticals;
-    private int majors;
-    private int minors;
-    private int infos;
+    private Integer blockers;
+    private Integer criticals;
+    private Integer majors;
+    private Integer minors;
+    private Integer infos;
 
-    public static Violations sumViolations(final Violations a, final Violations b) {
+    public static Violations sumViolations(final ViolationSource a, final ViolationSource b) {
         return Violations
                 .builder()
                 .blockers(a.getBlockers() + b.getBlockers())
@@ -41,7 +43,7 @@ public class Violations {
                 .build();
     }
 
-    public void addViolations(final Violations violations) {
+    public void addViolations(final ViolationSource violations) {
                 setBlockers(getBlockers() + violations.getBlockers());
                 setCriticals(getCriticals() + violations.getCriticals());
                 setMajors(getMajors() + violations.getMajors());

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/EmptyGroupMemberSummaryProjection.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/EmptyGroupMemberSummaryProjection.java
@@ -1,0 +1,47 @@
+package pl.consdata.ico.sqcompanion.violation.group.summary;
+
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+
+
+@RequiredArgsConstructor
+public class EmptyGroupMemberSummaryProjection implements GroupMemberSummaryProjection {
+    private final LocalDate formDate;
+    private final String id;
+
+    @Override
+    public String userId() {
+        return id;
+    }
+
+    @Override
+    public LocalDate date() {
+        return formDate;
+    }
+
+    @Override
+    public Integer blockers() {
+        return 0;
+    }
+
+    @Override
+    public Integer criticals() {
+        return 0;
+    }
+
+    @Override
+    public Integer majors() {
+        return 0;
+    }
+
+    @Override
+    public Integer minors() {
+        return 0;
+    }
+
+    @Override
+    public Integer infos() {
+        return 0;
+    }
+}

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/EmptyGroupProjectSummaryProjection.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/EmptyGroupProjectSummaryProjection.java
@@ -1,0 +1,46 @@
+package pl.consdata.ico.sqcompanion.violation.group.summary;
+
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+
+@RequiredArgsConstructor
+public class EmptyGroupProjectSummaryProjection implements GroupProjectSummaryProjection {
+    private final LocalDate formDate;
+    private final String id;
+
+    @Override
+    public String projectKey() {
+        return id;
+    }
+
+    @Override
+    public LocalDate date() {
+        return formDate;
+    }
+
+    @Override
+    public Integer blockers() {
+        return 0;
+    }
+
+    @Override
+    public Integer criticals() {
+        return 0;
+    }
+
+    @Override
+    public Integer majors() {
+        return 0;
+    }
+
+    @Override
+    public Integer minors() {
+        return 0;
+    }
+
+    @Override
+    public Integer infos() {
+        return 0;
+    }
+}

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/GroupMemberSummaryProjection.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/GroupMemberSummaryProjection.java
@@ -1,0 +1,29 @@
+package pl.consdata.ico.sqcompanion.violation.group.summary;
+
+import org.springframework.beans.factory.annotation.Value;
+
+import java.time.LocalDate;
+
+
+public interface GroupMemberSummaryProjection {
+    @Value("#{target.userId}")
+    String userId();
+
+    @Value("#{target.date}")
+    LocalDate date();
+
+    @Value("#{target.blockers}")
+    Integer blockers();
+
+    @Value("#{target.criticals}")
+    Integer criticals();
+
+    @Value("#{target.majors}")
+    Integer majors();
+
+    @Value("#{target.minors}")
+    Integer minors();
+
+    @Value("#{target.infos}")
+    Integer infos();
+}

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/GroupProjectSummaryProjection.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/GroupProjectSummaryProjection.java
@@ -1,0 +1,29 @@
+package pl.consdata.ico.sqcompanion.violation.group.summary;
+
+import org.springframework.beans.factory.annotation.Value;
+
+import java.time.LocalDate;
+
+
+public interface GroupProjectSummaryProjection {
+    @Value("#{target.projectKey}")
+    String projectKey();
+
+    @Value("#{target.date}")
+    LocalDate date();
+
+    @Value("#{target.blockers}")
+    Integer blockers();
+
+    @Value("#{target.criticals}")
+    Integer criticals();
+
+    @Value("#{target.majors}")
+    Integer majors();
+
+    @Value("#{target.minors}")
+    Integer minors();
+
+    @Value("#{target.infos}")
+    Integer infos();
+}

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/GroupViolationSummaryHistoryEntry.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/GroupViolationSummaryHistoryEntry.java
@@ -1,0 +1,73 @@
+package pl.consdata.ico.sqcompanion.violation.group.summary;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import pl.consdata.ico.sqcompanion.violation.Violations;
+import pl.consdata.ico.sqcompanion.violation.user.ViolationHistorySource;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Entity(name = "group_violations_summary_history_entries")
+@Table(
+        indexes = {
+                @Index(name = "IDX_GROUP_VIOLATIONS_SUMMARY_HISTORY_ENTRIES_GROUP_ID", columnList = "groupId"),
+                @Index(name = "IDX_GROUP_VIOLATIONS_SUMMARY_HISTORY_ENTRIES_GROUP_ID_PROJECT_KEY", columnList = "groupId,projectKey"),
+                @Index(name = "IDX_GROUP_VIOLATIONS_SUMMARY_HISTORY_ENTRIES_GROUP_ID_PROJECT_KEY_USER_ID", columnList = "groupId,projectKey,userId"),
+                @Index(name = "IDX_GROUP_VIOLATIONS_SUMMARY_HISTORY_ENTRIES_GROUP_ID_PROJECT_KEY_USER_ID_DATE", columnList = "groupId,projectKey,userId,date")
+        }
+)
+@Data
+@Builder(toBuilder = true)
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class GroupViolationSummaryHistoryEntry implements ViolationHistorySource {
+
+    @Id
+    private String id;
+    private String serverId;
+    private String userId;
+    private String groupId;
+    private String projectKey;
+    private Integer blockers;
+    private Integer criticals;
+    private Integer majors;
+    private Integer minors;
+    private Integer infos;
+    private LocalDate date;
+
+    public static String combineId(final String serverId, final String groupId, final String projectKey, final String userId, final LocalDate date) {
+        return String.format(
+                "%s$%s$%s$%s$%s",
+                serverId,
+                groupId,
+                projectKey,
+                userId,
+                date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        );
+    }
+
+    public static GroupViolationSummaryHistoryEntry empty() {
+        return GroupViolationSummaryHistoryEntry
+                .builder()
+                .blockers(0)
+                .criticals(0)
+                .majors(0)
+                .minors(0)
+                .infos(0)
+                .build();
+    }
+
+    public static Violations asViolations(List<GroupViolationSummaryHistoryEntry> entries) {
+        Violations violations = Violations.empty();
+        entries.forEach(violations::addViolations);
+        return violations;
+    }
+}

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/GroupViolationSummaryHistoryRepository.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/GroupViolationSummaryHistoryRepository.java
@@ -1,0 +1,33 @@
+package pl.consdata.ico.sqcompanion.violation.group.summary;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface GroupViolationSummaryHistoryRepository extends JpaRepository<GroupViolationSummaryHistoryEntry, Long> {
+
+    Optional<GroupViolationSummaryHistoryEntry> findFirstByGroupIdAndProjectKeyAndDate(String groupId, String projectKey, LocalDate date);
+
+    Optional<GroupViolationSummaryHistoryEntry> findFirstByGroupIdAndProjectKeyAndUserIdAndDate(String groupId, String projectKey, String userId, LocalDate date);
+
+    List<GroupViolationSummaryHistoryEntry> findAllByGroupIdAndProjectKeyInAndDateBetween(String groupId, List<String> projectKey, LocalDate from, LocalDate to);
+
+    List<GroupViolationSummaryHistoryEntry> findAllByGroupIdAndProjectKeyAndDateBetween(String groupId, String projectKey, LocalDate from, LocalDate to);
+
+    List<GroupViolationSummaryHistoryEntry> findAllByGroupIdAndDateBetween(String groupId, LocalDate from, LocalDate to);
+
+    List<GroupViolationSummaryHistoryEntry> findAllByGroupIdAndDateBetweenAndUserIdIn(String groupId, LocalDate from, LocalDate to, List<String> userIds);
+
+    @Query(value = "select PROJECT_KEY as projectKey, DATE as date, SUM(BLOCKERS) as blockers, SUM(CRITICALS) as criticals, SUM(MAJORS) as majors, SUM(MINORS) as minors, SUM(INFOS) as infos from GROUP_VIOLATIONS_SUMMARY_HISTORY_ENTRIES where GROUP_ID = :groupId and date = :date group by PROJECT_KEY, DATE", nativeQuery = true)
+    List<GroupProjectSummaryProjection> groupByProjects(@Param("groupId") String groupId, @Param("date") LocalDate date);
+
+    @Query(value = "select USER_ID as userId, DATE as date, SUM(BLOCKERS) as blockers, SUM(CRITICALS) as criticals, SUM(MAJORS) as majors, SUM(MINORS) as minors, SUM(INFOS) as infos from GROUP_VIOLATIONS_SUMMARY_HISTORY_ENTRIES where GROUP_ID = :groupId and date = :date group by USER_ID, DATE", nativeQuery = true)
+    List<GroupMemberSummaryProjection> groupByMembers(@Param("groupId") String groupId, @Param("date") LocalDate date);
+
+    @Query(value = "select SUM(BLOCKERS) as blockers, SUM(CRITICALS) as criticals, SUM(MAJORS) as majors, SUM(MINORS) as minors, SUM(INFOS) as infos from GROUP_VIOLATIONS_SUMMARY_HISTORY_ENTRIES where GROUP_ID = :groupId and DATE = :date group by GROUP_ID ", nativeQuery = true)
+    Optional<GroupViolationsSummaryProjection> groupViolations(@Param("groupId") String groupId, @Param("date")  LocalDate date);
+}

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/GroupViolationsHistoryService.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/GroupViolationsHistoryService.java
@@ -1,0 +1,254 @@
+package pl.consdata.ico.sqcompanion.violation.group.summary;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import pl.consdata.ico.sqcompanion.config.model.GroupLightModel;
+import pl.consdata.ico.sqcompanion.members.MemberService;
+import pl.consdata.ico.sqcompanion.members.MembersViolationsHistoryDiff;
+import pl.consdata.ico.sqcompanion.repository.Group;
+import pl.consdata.ico.sqcompanion.repository.Project;
+import pl.consdata.ico.sqcompanion.repository.RepositoryService;
+import pl.consdata.ico.sqcompanion.violation.ViolationHistoryEntry;
+import pl.consdata.ico.sqcompanion.violation.Violations;
+import pl.consdata.ico.sqcompanion.violation.ViolationsHistory;
+import pl.consdata.ico.sqcompanion.violation.project.GroupViolationsHistoryDiff;
+import pl.consdata.ico.sqcompanion.violation.project.ProjectViolationsHistoryDiff;
+import pl.consdata.ico.sqcompanion.violation.user.summary.UserProjectSummaryViolationHistoryEntry;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Optional.ofNullable;
+import static pl.consdata.ico.sqcompanion.violation.group.summary.GroupViolationSummaryHistoryEntry.asViolations;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GroupViolationsHistoryService {
+    private final MemberService memberService;
+    private final RepositoryService repositoryService;
+    private final GroupViolationSummaryHistoryRepository repository;
+
+    public void addToGroupHistory(UserProjectSummaryViolationHistoryEntry userEntry) {
+        final List<String> groups = memberService.memberGroups(userEntry.getUserId()).stream().map(GroupLightModel::getUuid).collect(Collectors.toList());
+        repositoryService.getRootGroup().getAllGroups().stream().filter(group -> group.getProject(userEntry.getProjectKey()).isPresent())
+                .map(Group::getUuid)
+                .filter(groups::contains)
+                .map(this::getGroupsRecursive)
+                .flatMap(List::stream)
+                .collect(Collectors.toSet())
+                .forEach(uuid -> addToGroupHistory(uuid, userEntry));
+    }
+
+    private List<String> getGroupsRecursive(String uuid) {
+        List<String> output = new ArrayList<>();
+        output.add(uuid);
+        repositoryService.getGroup(uuid).ifPresent(group -> output.addAll(group.getParentGroups().stream().map(GroupLightModel::getUuid).collect(Collectors.toList())));
+        return output;
+    }
+
+    private void addToGroupHistory(String groupId, UserProjectSummaryViolationHistoryEntry userEntry) {
+        log.info("      Add user {} violations to group summary {} for project{}", userEntry.getUserId(), groupId, userEntry.getProjectKey());
+        repository.save(repository.findFirstByGroupIdAndProjectKeyAndUserIdAndDate(groupId, userEntry.getProjectKey(), userEntry.getUserId(), userEntry.getDate())
+                .map(entry -> {
+                    entry.setBlockers(entry.getBlockers() + userEntry.getBlockers());
+                    entry.setCriticals(entry.getCriticals() + userEntry.getCriticals());
+                    entry.setMajors(entry.getMajors() + userEntry.getMajors());
+                    entry.setMinors(entry.getMinors() + userEntry.getMinors());
+                    entry.setInfos(entry.getInfos() + userEntry.getInfos());
+                    return entry;
+                })
+                .orElse(GroupViolationSummaryHistoryEntry.builder()
+                        .id(GroupViolationSummaryHistoryEntry.combineId(userEntry.getServerId(), groupId, userEntry.getProjectKey(), userEntry.getUserId(), userEntry.getDate()))
+                        .serverId(userEntry.getServerId())
+                        .groupId(groupId)
+                        .userId(userEntry.getUserId())
+                        .date(userEntry.getDate())
+                        .projectKey(userEntry.getProjectKey())
+                        .blockers(userEntry.getBlockers())
+                        .criticals(userEntry.getCriticals())
+                        .majors(userEntry.getMajors())
+                        .minors(userEntry.getMinors())
+                        .infos(userEntry.getInfos())
+                        .build()));
+    }
+
+    public ViolationsHistory getGroupViolationsHistory(Group group, Optional<Integer> daysLimit) {
+        List<String> projects = group.getAllProjects().stream().map(Project::getKey).collect(Collectors.toList());
+        return new ViolationsHistory(repository.findAllByGroupIdAndProjectKeyInAndDateBetween(group.getUuid(), projects, LocalDate.now().minusDays(daysLimit.orElse(30)), LocalDate.now().minusDays(1))
+                .stream()
+                .collect(Collectors.groupingBy(GroupViolationSummaryHistoryEntry::getDate))
+                .entrySet()
+                .stream()
+                .map(item -> ViolationHistoryEntry.builder()
+                        .date(item.getKey())
+                        .violations(asViolations(item.getValue()))
+                        .build()).sorted(Comparator.comparing(ViolationHistoryEntry::getDate))
+                .collect(Collectors.toList()));
+    }
+
+    public GroupViolationsHistoryDiff getGroupsUserViolationsHistoryDiff(Group group, LocalDate fromDate, LocalDate toDate) {
+        return null;
+    }
+
+    public ViolationsHistory getProjectViolationsHistory(Group group, Project project, Optional<Integer> daysLimit) {
+        return new ViolationsHistory(repository.findAllByGroupIdAndProjectKeyAndDateBetween(group.getUuid(), project.getKey(), LocalDate.now().minusDays(daysLimit.orElse(30)), LocalDate.now().minusDays(1))
+                .stream()
+                .collect(Collectors.groupingBy(GroupViolationSummaryHistoryEntry::getDate))
+                .entrySet()
+                .stream()
+                .map(item -> ViolationHistoryEntry.builder()
+                        .date(item.getKey())
+                        .violations(asViolations(item.getValue()))
+                        .build())
+                .sorted(Comparator.comparing(ViolationHistoryEntry::getDate))
+                .collect(Collectors.toList()));
+    }
+
+    public ProjectViolationsHistoryDiff getProjectViolationsHistoryDiff(Group group, Project project, LocalDate fromDate, LocalDate toDate) {
+        return null;
+    }
+
+
+    public List<ProjectViolationsHistoryDiff> getGroupProjectsViolationsHistoryDiff(Group group, Optional<List<String>> membersIds, Optional<Integer> daysLimit) {
+        return getGroupProjectsViolationsHistoryDiff(group, LocalDate.now().minusDays(daysLimit.orElse(30)), LocalDate.now().minusDays(1), membersIds);
+    }
+
+    public List<ProjectViolationsHistoryDiff> getGroupProjectsViolationsHistoryDiff(Group group, LocalDate fromDate, LocalDate toDate, Optional<List<String>> membersIds) {
+        if (membersIds.isPresent()) {
+            return emptyList();
+        } else {
+            Map<String, List<GroupProjectSummaryProjection>> fromViolations = repository.groupByProjects(group.getUuid(), fromDate).stream().collect(Collectors.groupingBy(GroupProjectSummaryProjection::projectKey));
+            Map<String, List<GroupProjectSummaryProjection>> toViolations = repository.groupByProjects(group.getUuid(), toDate).stream().collect(Collectors.groupingBy(GroupProjectSummaryProjection::projectKey));
+
+            return toViolations.entrySet()
+                    .stream()
+                    .map(entry -> {
+                        GroupProjectSummaryProjection toDateEntry = entry.getValue().get(0); // TODO if project removed
+                        GroupProjectSummaryProjection fromDateEntry = ofNullable(fromViolations.get(entry.getKey())).orElse(singletonList(new EmptyGroupProjectSummaryProjection(fromDate, entry.getKey()))).get(0);
+                        return createProjectViolationsHistoryDiff(fromDateEntry, toDateEntry, fromDate, toDate);
+                    })
+                    .collect(Collectors.toList());
+
+        }
+    }
+
+    private ProjectViolationsHistoryDiff createProjectViolationsHistoryDiff(GroupProjectSummaryProjection fromDateEntry, GroupProjectSummaryProjection toDateEntry, LocalDate fromDate, LocalDate toDate) {
+        final Violations addedViolations = Violations.empty();
+        final Violations removedViolations = Violations.empty();
+
+        final Violations violationsDiff = Violations
+                .builder()
+                .blockers(toDateEntry.blockers() - fromDateEntry.blockers())
+                .criticals(toDateEntry.criticals() - fromDateEntry.criticals())
+                .majors(toDateEntry.majors() - fromDateEntry.majors())
+                .minors(toDateEntry.minors() - fromDateEntry.minors())
+                .infos(toDateEntry.infos() - fromDateEntry.infos())
+                .build();
+        mergeProjectViolationsToAddedOrRemovedGroupViolations(addedViolations, removedViolations, violationsDiff);
+        return ProjectViolationsHistoryDiff
+                .builder()
+                .fromDate(fromDate)
+                .toDate(toDate)
+                .addedViolations(addedViolations)
+                .removedViolations(removedViolations)
+                .projectKey(toDateEntry.projectKey())
+                .violationsDiff(violationsDiff)
+                .build();
+    }
+
+    private void mergeProjectViolationsToAddedOrRemovedGroupViolations(
+            final Violations addedViolations,
+            final Violations removedViolations,
+            final Violations violations) {
+        if (violations.getBlockers() >= 0) {
+            addedViolations.addBlockers(violations.getBlockers());
+        } else {
+            removedViolations.addBlockers(Math.abs(violations.getBlockers()));
+        }
+        if (violations.getCriticals() >= 0) {
+            addedViolations.addCriticals(violations.getCriticals());
+        } else {
+            removedViolations.addCriticals(Math.abs(violations.getCriticals()));
+        }
+        if (violations.getMajors() >= 0) {
+            addedViolations.addMajors(violations.getMajors());
+        } else {
+            removedViolations.addMajors(Math.abs(violations.getMajors()));
+        }
+        if (violations.getMinors() >= 0) {
+            addedViolations.addMinors(violations.getMinors());
+        } else {
+            removedViolations.addMinors(Math.abs(violations.getMinors()));
+        }
+        if (violations.getInfos() >= 0) {
+            addedViolations.addInfos(violations.getInfos());
+        } else {
+            removedViolations.addInfos(Math.abs(violations.getInfos()));
+        }
+    }
+
+    public List<MembersViolationsHistoryDiff> getGroupMembersViolationsHistoryDiff(Group group, Optional<List<String>> projects, Optional<Integer> daysLimit) {
+        return getGroupMembersViolationsHistoryDiff(group, LocalDate.now().minusDays(daysLimit.orElse(30)), LocalDate.now().minusDays(1), projects);
+    }
+
+    public List<MembersViolationsHistoryDiff> getGroupMembersViolationsHistoryDiff(Group group, LocalDate fromDate, LocalDate toDate, Optional<List<String>> projects) {
+        if (projects.isPresent()) {
+            return emptyList();
+        } else {
+            Map<String, List<GroupMemberSummaryProjection>> fromViolations = repository.groupByMembers(group.getUuid(), fromDate).stream().collect(Collectors.groupingBy(GroupMemberSummaryProjection::userId));
+            Map<String, List<GroupMemberSummaryProjection>> toViolations = repository.groupByMembers(group.getUuid(), toDate).stream().collect(Collectors.groupingBy(GroupMemberSummaryProjection::userId));
+
+            return toViolations.entrySet()
+                    .stream()
+                    .map(entry -> {
+                        GroupMemberSummaryProjection toDateEntry = entry.getValue().get(0); // TODO if project removed
+                        GroupMemberSummaryProjection fromDateEntry = ofNullable(fromViolations.get(entry.getKey())).orElse(singletonList(new EmptyGroupMemberSummaryProjection(fromDate, entry.getKey()))).get(0);
+                        return createMemberViolationsHistoryDiff(fromDateEntry, toDateEntry, fromDate, toDate);
+                    })
+                    .collect(Collectors.toList());
+
+        }
+    }
+
+    public Violations getViolations(String groupId) {
+        return repository.groupViolations(groupId, LocalDate.now().minusDays(1)).map(projection -> Violations.builder()
+                .blockers(projection.blockers())
+                .criticals(projection.criticals())
+                .majors(projection.majors())
+                .minors(projection.minors())
+                .infos(projection.infos())
+                .build()).orElse(Violations.empty());
+    }
+
+    private MembersViolationsHistoryDiff createMemberViolationsHistoryDiff(GroupMemberSummaryProjection fromDateEntry, GroupMemberSummaryProjection toDateEntry, LocalDate fromDate, LocalDate toDate) {
+        final Violations addedViolations = Violations.empty();
+        final Violations removedViolations = Violations.empty();
+
+        final Violations violationsDiff = Violations
+                .builder()
+                .blockers(toDateEntry.blockers() - fromDateEntry.blockers())
+                .criticals(toDateEntry.criticals() - fromDateEntry.criticals())
+                .majors(toDateEntry.majors() - fromDateEntry.majors())
+                .minors(toDateEntry.minors() - fromDateEntry.minors())
+                .infos(toDateEntry.infos() - fromDateEntry.infos())
+                .build();
+        mergeProjectViolationsToAddedOrRemovedGroupViolations(addedViolations, removedViolations, violationsDiff);
+        return MembersViolationsHistoryDiff
+                .builder()
+                .fromDate(fromDate)
+                .toDate(toDate)
+                .addedViolations(addedViolations)
+                .removedViolations(removedViolations)
+                .uuid(toDateEntry.userId())
+                .name(toDateEntry.userId())
+                .violationsDiff(violationsDiff)
+                .build();
+    }
+
+    //TODO DIFF
+}

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/GroupViolationsSummaryProjection.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/group/summary/GroupViolationsSummaryProjection.java
@@ -1,0 +1,23 @@
+package pl.consdata.ico.sqcompanion.violation.group.summary;
+
+import org.springframework.beans.factory.annotation.Value;
+
+import java.time.LocalDate;
+
+
+public interface GroupViolationsSummaryProjection {
+    @Value("#{target.blockers}")
+    Integer blockers();
+
+    @Value("#{target.criticals}")
+    Integer criticals();
+
+    @Value("#{target.majors}")
+    Integer majors();
+
+    @Value("#{target.minors}")
+    Integer minors();
+
+    @Value("#{target.infos}")
+    Integer infos();
+}

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/user/ViolationHistorySource.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/user/ViolationHistorySource.java
@@ -2,18 +2,7 @@ package pl.consdata.ico.sqcompanion.violation.user;
 
 import java.time.LocalDate;
 
-public interface ViolationHistorySource {
+public interface ViolationHistorySource extends ViolationSource {
 
     LocalDate getDate();
-
-    Integer getBlockers();
-
-    Integer getCriticals();
-
-    Integer getMajors();
-
-    Integer getMinors();
-
-    Integer getInfos();
-
 }

--- a/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/user/ViolationSource.java
+++ b/sonarqube-companion-rest/src/main/java/pl/consdata/ico/sqcompanion/violation/user/ViolationSource.java
@@ -1,0 +1,13 @@
+package pl.consdata.ico.sqcompanion.violation.user;
+
+public interface ViolationSource {
+    Integer getBlockers();
+
+    Integer getCriticals();
+
+    Integer getMajors();
+
+    Integer getMinors();
+
+    Integer getInfos();
+}


### PR DESCRIPTION
Agregacja naruszeń w grupach. Do tej pory naruszeń grup były przeliczane live na podstawie naruszeń członków. Działa to strasznie wolno. Od teraz codziennie naruszenia są odkładane w oddzielnej tablei w raz z informacją o aktualnej przynależności do grup. Dzieki temu część obsługi została przeniesiona na baze  z użyciem group by. Nie będzie też efaktu "zabrania" naruszeń w przypadku zmiany przynależności do grupy.